### PR TITLE
[LabKey UX] Edit standard settings name/label/type - API Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JavaScript package for interacting with [LabKey Server](https://www.labkey.com/)
 
 Written with joy in TypeScript.
 
-## v0.0.12 - Alpha
+## v0.0.13 - Alpha
 
 This package is under development. We're preparing the 1.0.0 release but in the meantime treat this package as experimental. All code is subject to change.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Domain.ts
+++ b/src/labkey/Domain.ts
@@ -107,8 +107,9 @@ export function drop(config: DropDomainOptions): void {
 export interface GetDomainOptions {
     containerPath?: string
     failure?: () => any
-    queryName: string
-    schemaName: string
+    queryName?: string
+    schemaName?: string
+    domainId?: number
     success?: () => any
 }
 
@@ -132,7 +133,8 @@ export function get(config: GetDomainOptions): void {
         failure: getCallbackWrapper(options.failure, this, true),
         params: {
             schemaName: options.schemaName,
-            queryName: options.queryName
+            queryName: options.queryName,
+            domainId: options.domainId
         }
     });
 
@@ -142,8 +144,9 @@ export interface SaveDomainOptions {
     containerPath?: string
     domainDesign?: any
     failure?: () => any
-    queryName: string
-    schemaName: string
+    queryName?: string
+    schemaName?: string
+    domainId?: number
     success?: () => any
 }
 
@@ -169,7 +172,8 @@ export function save(config: SaveDomainOptions): void {
         jsonData: {
             domainDesign: options.domainDesign,
             schemaName: options.schemaName,
-            queryName: options.queryName
+            queryName: options.queryName,
+            domainId: options.domainId
         }
     });
 }


### PR DESCRIPTION
For the new Domain Designer, need to be able to retrieve and update a domain by the domain Id.  This has already been added to the standard Java and JS api.  Just need to add the parameters here to be passed through to the Java API.  Only making this available for the config object, not the parameter list.  Bumped version here.