### PR TITLE
Lookup Field Support in Domain Designer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JavaScript package for interacting with [LabKey Server](https://www.labkey.com/)
 
 Written with joy in TypeScript.
 
-## v0.0.17 - Alpha
+## v0.0.18 - Alpha
 
 This package is under development. We're preparing the 1.0.0 release but in the meantime treat this package as experimental. All code is subject to change.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.18.alpha.1",
+  "version": "0.0.18-fb-domain-lookup-deux.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.17",
+  "version": "0.0.18.alpha.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.18-fb-domain-lookup-deux.2",
+  "version": "0.0.18",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -175,6 +175,7 @@ export interface IGetQueriesOptions {
     includeColumns?: boolean
     includeUserQueries?: boolean
     includeSystemQueries?: boolean
+    queryDetailColumns?: boolean
     schemaName: string
     scope?: any
     success?: Function
@@ -194,7 +195,8 @@ export function getQueries(options: IGetQueriesOptions): XMLHttpRequest {
         schemaName: 'schemaName',
         includeColumns: 'includeColumns',
         includeUserQueries: 'includeUserQueries',
-        includeSystemQueries: 'includeSystemQueries'
+        includeSystemQueries: 'includeSystemQueries',
+        queryDetailColumns: 'queryDetailColumns'
     }, false, false);
 
     return request({


### PR DESCRIPTION
**Summary**

Provides support for `query-getQueries.api` returning `getQueryDetail.api` column objects which are more rich in metadata.

**Contingent Pull Requests**
- Platform MR: https://github.com/LabKey/platform/pull/234