### PR TITLE
Update deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you would like to experiment with running this code against LabKey Server it 
 
 #### Deploy Using Experimental Build
 
-:warning: This will modify files in your git enlistment. Double check your commits and be sure to revert and changes when you are done experimenting!
+:warning: This will modify files in your git enlistment. Double check your commits and be sure to revert any changes when you are done experimenting!
 
 To get started edit the `<labkey root>/server/modules/core/build.js` file and set `USE_LABKEY_API` to `true`.
 
@@ -73,7 +73,7 @@ Next, perform a Gradle build from the top of your LabKey enlistment:
 ./gradlew deployApp
 ```
 
-Once, the build is complete you can startup the server and the code for the APIs will be supplied from this package. This can be verified
+Once the build is complete, you can start the server and the code for the APIs will be supplied from this package. This can be verified
 by checking the browser console. You should see:
 
 ```
@@ -95,7 +95,7 @@ Steps:
 </libraries>
 ```
 
-Now you can startup the server and the code for the APIs will be supplied from this package. This can be verified
+Now you can start the server and the code for the APIs will be supplied from this package. This can be verified
 by checking the browser console. You should see:
 
 ```

--- a/README.md
+++ b/README.md
@@ -58,28 +58,34 @@ If you would like to experiment with running this code against LabKey Server it 
 
 #### Deploy Using Experimental Build
 
+:warning: This will modify files in your git enlistment. Double check your commits and be sure to revert and changes when you are done experimenting!
+
 To get started edit the `<labkey root>/server/modules/core/build.js` file and set `USE_LABKEY_API` to `true`.
 
 ```js
 const USE_LABKEY_API = true;
 ```
 
-Next, you can either perform a Gradle clean build or run the node portion of the build directly:
+Next, perform a Gradle build from the top of your LabKey enlistment:
 
 ```sh
-# From <labkey root>/server/modules/core
-npm install
-node build.js
+# From <labkey root>
+./gradlew deployApp
 ```
 
-Now you can startup the server and the code for the APIs will be supplied from this package.
+Once, the build is complete you can startup the server and the code for the APIs will be supplied from this package. This can be verified
+by checking the browser console. You should see:
+
+```
+LABKEY is now running @labkey/api.
+```
 
 #### Deploy From Source
 
 Steps:
-1. Navigate to `<labkey root>/server/api/webapp/` and clone this repository.
+1. Navigate to `<labkey root>/server/modules/platform/api/webapp/` and clone this repository.
 2. Navigate to the package directory and run `npm install` followed by `npm run build`.
-3. Open `<labkey root>/server/api/webapp/clientapi_core.lib.xml` and replace the contents
+3. Open `<labkey root>/server/modules/platform/api/webapp/clientapi_core.lib.xml` and replace the contents
 
 ```xml
 <libraries xmlns="http://labkey.org/clientLibrary/xml/">
@@ -89,7 +95,12 @@ Steps:
 </libraries>
 ```
 
-Now you can startup the server and the code for the APIs will be supplied from this package.
+Now you can startup the server and the code for the APIs will be supplied from this package. This can be verified
+by checking the browser console. You should see:
+
+```
+LABKEY is now running @labkey/api.
+```
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JavaScript package for interacting with [LabKey Server](https://www.labkey.com/)
 
 Written with joy in TypeScript.
 
-## v0.0.20 - Alpha
+## v0.0.21 - Alpha
 
 This package is under development. We're preparing the 1.0.0 release but in the meantime treat this package as experimental. All code is subject to change.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JavaScript package for interacting with [LabKey Server](https://www.labkey.com/)
 
 Written with joy in TypeScript.
 
-## v0.0.21 - Alpha
+## v0.0.22 - Alpha
 
 This package is under development. We're preparing the 1.0.0 release but in the meantime treat this package as experimental. All code is subject to change.
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ Next, perform a Gradle build from the top of your LabKey enlistment:
 ./gradlew deployApp
 ```
 
-Once the build is complete, you can start the server and the code for the APIs will be supplied from this package. This can be verified
-by checking the browser console. You should see:
+Once the build is complete, you can start the server and the code for the APIs will be supplied from this package.
+This can be verified by opening the browser console and typing:
 
+```js
+LABKEY.__package__
 ```
-LABKEY is now running @labkey/api.
-```
+
+If installed correctly, `__package__` will contain package information such as the version of the package you're using.
 
 #### Deploy From Source
 
@@ -96,11 +98,13 @@ Steps:
 ```
 
 Now you can start the server and the code for the APIs will be supplied from this package. This can be verified
-by checking the browser console. You should see:
+by opening the browser console and typing:
 
+```js
+LABKEY.__package__
 ```
-LABKEY is now running @labkey/api.
-```
+
+If installed correctly, `__package__` will contain package information such as the version of the package you're using.
 
 ## Publishing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.21-fb-deployApiJs.0",
+  "version": "0.0.21-fb-deployApiJs.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.20",
+  "version": "0.0.21-fb-deployApiJs.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.21-fb-deployApiJs.1",
+  "version": "0.0.21",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/package.ts
+++ b/src/package.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The intent of this file is to a "single-source of truth" export of
+ * relevant package information.
+ */
+import { description, name, version } from '../package.json'
+
+export {
+    description,
+    name,
+    version
+}

--- a/src/wrapper-dom.ts
+++ b/src/wrapper-dom.ts
@@ -24,6 +24,7 @@
  */
 import * as API from './labkey'
 import * as DOM from './labkey/dom/index'
+import * as __package__ from './package'
 
 declare let LABKEY: any;
 
@@ -43,6 +44,7 @@ LABKEY.Report = API.Report;
 LABKEY.SchemaKey = API.SchemaKey;
 LABKEY.Specimen = API.Specimen;
 LABKEY.Visualization = API.Visualization;
+LABKEY.__package__ = __package__;
 
 // DOM
 LABKEY.Assay = Object.assign({}, API.Assay, DOM.Assay);

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -23,6 +23,7 @@
  * this file SHOULD NOT export anything.
  */
 import * as API from './labkey'
+import * as __package__ from './package'
 
 declare let LABKEY: any;
 
@@ -45,6 +46,4 @@ LABKEY.Security = API.Security;
 LABKEY.Specimen = API.Specimen;
 LABKEY.Utils = API.Utils;
 LABKEY.Visualization = API.Visualization;
-
-// Let our presence be known in experimental deployments. See README.md.
-console.log('LABKEY is now running @labkey/api.');
+LABKEY.__package__ = __package__;

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -45,3 +45,6 @@ LABKEY.Security = API.Security;
 LABKEY.Specimen = API.Specimen;
 LABKEY.Utils = API.Utils;
 LABKEY.Visualization = API.Visualization;
+
+// Let our presence be known in experimental deployments. See README.md.
+console.log('LABKEY is now running @labkey/api.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,14 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "target": "ES5",
+    "lib": [ "dom", "es2015" ],
+    "moduleResolution": "node",
     "noEmit": false,
-    "rootDir": "src",
-    "sourceMap": false,
     "noImplicitAny": true,
     "removeComments": true,
-    "lib": [
-      "DOM",
-      "es2015"
-    ]
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "sourceMap": false,
+    "target": "ES5"
   }
 }


### PR DESCRIPTION
#### Changes

- Update documentation for deploying to a LabKey Server.
- Expose `LABKEY.__package__` object containing package information about what is currently deployed. Currently, only exposed in browser targeted wrappers (i.e. `wrapper.ts` and `wrapper-dom.ts`).
- add "resolveJsonModule" to TS compiler options. Order options.

#### Related PRs

- Platform: https://github.com/LabKey/platform/pull/491

#### What caused this?

- `@labkey/api` had been a dependency of `platform/core/package.json` to support the experimental deployment. This dependency was removed with https://github.com/LabKey/platform/commit/303cf5c3eeb57b786a6b393c760aadc000769732. Removing this made the "Deploy Using Experimental Build" section of the README.md no longer work.
- Pathing had changed between the core and api modules in LabKey after the migration to git.