### PR TITLE
Item 6508: Security api fixes for getPolicy and getRoles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.26-fb-smPermissionsManagement.0",
+  "version": "0.0.26",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.25",
+  "version": "0.0.26-fb-smPermissionsManagement.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/Permission.ts
+++ b/src/labkey/security/Permission.ts
@@ -21,10 +21,10 @@ import { roles } from './constants'
 
 export interface GetGroupPermissionsOptions {
     containerPath?: string
-    failure?: () => any
+    failure?: (error?: any) => any
     includeSubfolders?: boolean
     scope?: any
-    success?: () => any
+    success?: (data?: any) => any
 }
 
 /**
@@ -119,9 +119,9 @@ export function getRole(perms: number): string {
 
 export interface GetRolesOptions {
     containerPath?: string
-    failure?: () => any
+    failure?: (error?: any) => any
     scope?: any
-    success?: () => any
+    success?: (data?: any) => any
 }
 
 export interface GetRolesResponse {

--- a/src/labkey/security/Policy.ts
+++ b/src/labkey/security/Policy.ts
@@ -113,10 +113,7 @@ export function getPolicy(config: GetPolicyOptions): XMLHttpRequest {
         },
         success: getCallbackWrapper(function(data: GetPolicyResponse, req: any) {
             data.policy.requestedResourceId = config.resourceId;
-            // TODO: This is an Ext3 class -- should probably just deprecate this entirely and just hand back the response.
-            const { SecurityPolicy } = getServerContext();
-            let policy = new SecurityPolicy(data.policy);
-            getOnSuccess(config).call(config.scope || this, policy, data.relevantRoles, req);
+            getOnSuccess(config).call(config.scope || this, data.policy, data.relevantRoles, req);
         }, this),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true)
     });


### PR DESCRIPTION
- getPolicy was trying to create a SecurityPolicy object which is not a constructor
- getRoles was returning incorrect typescript info for the success and failure functions