### PR TITLE
Fix type annotations for selectRows success/failure callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.0.34 - 2020-02-25
+- Fix type signature for selectRows success and failure callbacks
 
 ## 0.0.32 - 2020-01-24
 - Item 6654: Changes to SaveDomain Api to include Warnings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.34-fb-fix-selectRows-callback.1",
+  "version": "0.0.34",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.34-fb-fix-selectRows-callback",
+  "version": "0.0.34-fb-fix-selectRows-callback.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.33",
+  "version": "0.0.34-fb-fix-selectRows-callback",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",
@@ -10,6 +10,7 @@
     "clean": "rimraf dist && npm run clean:docs",
     "clean:docs": "rimraf docs",
     "predeploy": "npm run build:docs",
+    "prepublishOnly": "npm run build",
     "deploy": "gh-pages -t -d docs",
     "setup": "npm install",
     "test": "cross-env NODE_ENV=test jest"

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -16,7 +16,7 @@
 import { request, RequestOptions } from '../Ajax'
 import { IFilter } from '../filter/Filter'
 import { buildURL } from '../ActionURL'
-import { getCallbackWrapper, getOnFailure, getOnSuccess, isArray } from '../Utils'
+import { ExtendedXMLHttpRequest, getCallbackWrapper, getOnFailure, getOnSuccess, isArray } from '../Utils';
 import { buildQueryParams, getMethod, getSuccessCallbackWrapper } from './Utils'
 
 /**
@@ -399,7 +399,7 @@ export interface ISelectRowsOptions {
      */
     containerPath?: string
     dataRegionName?: string
-    failure?: () => any
+    failure?: (data: any, response: ExtendedXMLHttpRequest, options: ISelectRowsOptions) => any
 
     /**
      * Array of objects created by Filter.create

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -399,7 +399,7 @@ export interface ISelectRowsOptions {
      */
     containerPath?: string
     dataRegionName?: string
-    failure?: (data: any, response: ExtendedXMLHttpRequest, options: ISelectRowsOptions) => any
+    failure?: (result: any, request: ExtendedXMLHttpRequest, options: ISelectRowsOptions) => any
 
     /**
      * Array of objects created by Filter.create
@@ -471,7 +471,7 @@ export interface ISelectRowsOptions {
      */
     sort?: string
     stripHiddenColumns?: boolean
-    success?: (result: ISelectRowsResults) => any
+    success?: (result: ISelectRowsResults, request: ExtendedXMLHttpRequest, options: ISelectRowsOptions) => any
 
     /**
      * The maximum number of milliseconds to allow for this operation before a timeout error (defaults to 30000).


### PR DESCRIPTION
Also added a call to `npm run build` via `prepublishOnly` so we run a build before publishing to prevent accidental empty publishes.