### PR TITLE
ContainerFilter enumeration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docs/
 node_modules/
 .idea/
 .envrc
+.gradle
 .npmrc
 npm-debug.log
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.## - 20##-##-##
+- Declare Query.ContainerFilter as an enum. Deprecate Query.containerFilter.
+
 ## 0.0.39 - 2020-03-06
 - Fix value casing of Query.containerFilter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.## - 20##-##-##
+## 0.0.40 - 2020-03-11
 - Declare Query.ContainerFilter as an enum. Deprecate Query.containerFilter.
 
 ## 0.0.39 - 2020-03-06

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JavaScript package for interacting with [LabKey Server](https://www.labkey.com/)
 
 Written with joy in TypeScript.
 
-## v0.0.37 - Alpha
+## v0.0.40 - Alpha
 
 This package is under development. We're preparing the 1.0.0 release but in the meantime treat this package as experimental. All code is subject to change.
 See the [CHANGELOG](CHANGELOG.md) for changes in this version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.40-fb-container-filter-enum.1",
+  "version": "0.0.40-fb-container-filter-enum.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.40-fb-container-filter-enum.2",
+  "version": "0.0.40",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.39",
+  "version": "0.0.40-fb-container-filter-enum.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Query.ts
+++ b/src/labkey/Query.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {
-    buildQueryParams, containerFilter, deleteQueryView, getQueries, getQueryViews,
+    buildQueryParams, ContainerFilter, containerFilter, deleteQueryView, getQueries, getQueryViews,
     getSchemas, getServerDate, saveQueryViews, sqlDateLiteral, sqlDateTimeLiteral,
     sqlStringLiteral, URL_COLUMN_PREFIX, validateQuery
 } from './query/Utils'
@@ -31,7 +31,8 @@ const experimental = {
 };
 
 export {
-    containerFilter,
+    ContainerFilter, // Enumeration
+    containerFilter, // backwards compatible reference
     buildQueryParams,
     deleteQueryView,
     deleteRows,

--- a/src/labkey/dom/Query.ts
+++ b/src/labkey/dom/Query.ts
@@ -17,6 +17,7 @@ import { buildURL } from '../ActionURL'
 import { request } from '../Ajax'
 import { getCallbackWrapper, getOnFailure, getOnSuccess, merge } from '../Utils'
 import { appendFilterParams } from '../filter/Filter'
+import { ContainerFilter } from '../query/Utils'
 
 import { FormWindow } from './constants'
 import { postToAction } from './Utils';
@@ -24,7 +25,7 @@ import { postToAction } from './Utils';
 declare let window: FormWindow;
 
 export interface IExportSqlOptions {
-    containerFilter?: string
+    containerFilter?: ContainerFilter
     containerPath?: string
     format?: string
     schemaName: string

--- a/src/labkey/query/ExecuteSql.ts
+++ b/src/labkey/query/ExecuteSql.ts
@@ -17,15 +17,15 @@ import { request } from '../Ajax'
 import { buildURL } from '../ActionURL'
 import { getCallbackWrapper, getOnFailure, getOnSuccess } from '../Utils'
 
-import { getSuccessCallbackWrapper } from './Utils'
+import { ContainerFilter, getSuccessCallbackWrapper } from './Utils'
 
 export interface IExecuteSqlOptions {
     /**
-     * One of the values of [[containerFilter]] that sets
-     * the scope of this query. Defaults to containerFilter.current, and is interpreted relative to
+     * One of the values of [[ContainerFilter]] that sets
+     * the scope of this query. Defaults to ContainerFilter.current, and is interpreted relative to
      * config.containerPath.
      */
-    containerFilter?: string
+    containerFilter?: ContainerFilter
 
     /**
      * The path to the container in which the schema and query are defined,

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -17,7 +17,7 @@ import { request, RequestOptions } from '../Ajax'
 import { IFilter } from '../filter/Filter'
 import { buildURL } from '../ActionURL'
 import { ExtendedXMLHttpRequest, getCallbackWrapper, getOnFailure, getOnSuccess, isArray } from '../Utils';
-import { buildQueryParams, getMethod, getSuccessCallbackWrapper } from './Utils'
+import { buildQueryParams, ContainerFilter, getMethod, getSuccessCallbackWrapper } from './Utils'
 
 /**
  * Delete rows.
@@ -247,11 +247,11 @@ export interface ISelectDistinctOptions {
     column: string
 
     /**
-     * One of the values of [[containerFilter]] that sets
-     * the scope of this query. Defaults to containerFilter.current, and is interpreted relative to
+     * One of the values of [[ContainerFilter]] that sets
+     * the scope of this query. Defaults to ContainerFilter.current, and is interpreted relative to
      * config.containerPath.
      */
-    containerFilter?: string
+    containerFilter?: ContainerFilter
     containerPath?: string
     dataRegionName?: string
     failure?: (error?: any, request?: XMLHttpRequest, options?: RequestOptions) => any
@@ -391,7 +391,13 @@ export interface ISelectRowsOptions {
      * and 'Peptide' is the name of a column in the related table).
      */
     columns?: string | Array<string>
-    containerFilter?: string
+
+    /**
+     * One of the values of [[ContainerFilter]] that sets
+     * the scope of this query. Defaults to ContainerFilter.current, and is interpreted relative to
+     * config.containerPath.
+     */
+    containerFilter?: ContainerFilter
 
     /**
      * The path to the container in which the schema and query are defined, if different than the current container.

--- a/src/labkey/query/Utils.spec.ts
+++ b/src/labkey/query/Utils.spec.ts
@@ -1,0 +1,22 @@
+import { ContainerFilter, containerFilter } from './Utils'
+
+describe('ContainerFilter', () => {
+    it('should be a case-sensitive string-based enum', () => {
+        // The "value" of the enumeration is expected to bind to Java classes which is case-sensitive
+        expect(ContainerFilter.allFolders).toEqual('AllFolders');
+        expect(ContainerFilter.current).toEqual('Current');
+        expect(ContainerFilter.currentAndFirstChildren).toEqual('CurrentAndFirstChildren');
+        expect(ContainerFilter.currentAndParents).toEqual('CurrentAndParents');
+        expect(ContainerFilter.currentAndSubfolders).toEqual('CurrentAndSubfolders');
+        expect(ContainerFilter.currentPlusProject).toEqual('CurrentPlusProject');
+        expect(ContainerFilter.currentPlusProjectAndShared).toEqual('CurrentPlusProjectAndShared');
+
+        // All "values" of the ContainerFilter enum should be covered here -- if it has changed
+        // this test will fail and the test should be updated accordingly.
+        expect(Object.keys(ContainerFilter).length).toEqual(7);
+    });
+    it('should be equivalent to "containerFilter"', () => {
+        // Backwards compatibilty suppport
+        expect(ContainerFilter).toStrictEqual(containerFilter);
+    });
+});

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -20,20 +20,39 @@ import { applyTranslated, ensureRegionName, getCallbackWrapper, getOnFailure, ge
 
 import { Response } from './Response'
 
-// Would have liked to use an enum but TypeScript's enums are number-based (as of 1.8)
-// https://basarat.gitbooks.io/typescript/content/docs/tips/stringEnums.html
-//
-// Additionally, cannot use 'type' here as we want to actually return a resolvable object
-// e.g. LABKEY.Query.containerFilter.current; // "current"
-export const containerFilter = {
-    current: 'Current',
-    currentAndFirstChildren: 'CurrentAndFirstChildren',
-    currentAndSubfolders: 'CurrentAndSubfolders',
-    currentPlusProject: 'CurrentPlusProject',
-    currentAndParents: 'CurrentAndParents',
-    currentPlusProjectAndShared: 'CurrentPlusProjectAndShared',
-    allFolders: 'AllFolders'
+/**
+ * An enumeration of the various container filters available. Note that not all
+ * data types and queries can contain that spans multiple containers. In those cases,
+ * all values will behave the same as current and show only data in the current container.
+ */
+export enum ContainerFilter {
+
+    /** Include all folders for which the user has read permission. */
+    allFolders = 'AllFolders',
+
+    /** Include the current folder only. */
+    current = 'Current',
+
+    /** Include the current folder and all first children, excluding workbooks. */
+    currentAndFirstChildren = 'CurrentAndFirstChildren',
+
+    /** Include the current folder and its parent folders. */
+    currentAndParents = 'CurrentAndParents',
+
+    /** Include the current folder and all subfolders. */
+    currentAndSubfolders = 'CurrentAndSubfolders',
+
+    /** Include the current folder and the project that contains it. */
+    currentPlusProject = 'CurrentPlusProject',
+
+    /** Include the current folder plus its project plus any shared folders. */
+    currentPlusProjectAndShared = 'CurrentPlusProjectAndShared',
 };
+
+/**
+ * @deprecated Backwards compatible reference to [[ContainerFilter]].
+ */
+export const containerFilter = ContainerFilter;
 
 export const URL_COLUMN_PREFIX = '_labkeyurl_';
 


### PR DESCRIPTION
#### Rationale

The `Query.containerFilter` is an object that acts as an enumeration of available container filter types in LKS. When this was originally ported to `@labkey/api` the version of TypeScript at the time didn't support string-based enumerations. This change makes `ContainerFilter` an exported `enum` to provide more type-safe usage and lookup of the available container filters.

#### Changes
* Add documentation for `ContainerFilter`.
* Provides backwards compatible reference to `containerFilter` (lowercase 'c') which still resolves in the `LABKEY` compliant source to a plain JS object like is declared in Query.js.
* Switches `executeSql` and `exportSql` to use this as the type for their interfaces.