### PR TITLE
Domain module updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.47 - 2020-04-06
+- Domain module updates.
+
 ## 0.0.46 - 2020-04-06
 - Security module updates.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Domain.ts
+++ b/src/labkey/Domain.ts
@@ -333,13 +333,18 @@ export function save(config: SaveDomainOptions): XMLHttpRequest {
     });
 }
 
-interface ListDomainsParams {
-    domainKinds?: Array<string>
+export interface ListDomainsParams {
+    domainKinds?: string[]
     includeFields?: boolean
     includeProjectAndShared?: boolean
 }
 
-export interface ListDomainsOptions extends ListDomainsParams, RequestCallbackOptions<DomainDesign[]> {
+export interface ListDomainsResponse {
+    data: DomainDesign[]
+    success: boolean
+}
+
+export interface ListDomainsOptions extends ListDomainsParams, RequestCallbackOptions<ListDomainsResponse> {
     containerPath?: string
 }
 


### PR DESCRIPTION
#### Changes
* Updates typings to use `RequestCallbackOptions` for `request`-based APIs.
* Switch `request`-based APIs to return `request` instead of `void` to allow user to handle response object.
* Switch endpoints to use more common pattern for parsing `success`/`failure`/`scope` parameters.
* Documentation updates.