### PR TITLE
Fix Security.getUserPermissions typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1 - 2020-04-07
+- Fix for typings of Security.getUserPermissions response.
+
 ## 0.1.0 - 2020-04-06
 - Feature parity with clientapi_core.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.1.1-fb-fix-perm-resp-type.0",
+  "version": "0.1.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.1.0",
+  "version": "0.1.1-fb-fix-perm-resp-type.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/Permission.ts
+++ b/src/labkey/security/Permission.ts
@@ -288,7 +288,37 @@ export function getSecurableResources(config: GetSecurableResourcesOptions): XML
     })
 }
 
-export interface GetUserPermissionsResponse extends PermissionsResponse {
+export interface UserPermissionsContainer extends PermissionsContainer {
+    /** An array of effective permission unique names the user has in this container. */
+    effectivePermissions: string[]
+    /**
+     * @deprecated
+     * The permissions the current user has in the container.
+     */
+    permissions: number
+    /**
+     * @deprecated
+     * The user's role value (e.g., 'READER'). Use this property for programmatic checks.
+     */
+    role: string
+    /**
+     * @deprecated
+     * A description of the group's permission role. This will correspond
+     * to the visible labels shown on the permissions page (e.g., 'Admin (all permissions)'.
+     */
+    roleLabel: string
+    /**
+     * An array of role unique names that this group is playing in the container. This replaces the
+     * existing roleLabel, role and permissions properties. Groups may now play multiple roles in a container
+     * and each role grants the user a set of permissions. Use the getRoles() method to retrieve information
+     * about the roles, including which permissions are granted by each role.
+     */
+    roles: string[]
+}
+
+export interface GetUserPermissionsResponse {
+    /** Information object describing the container's permission. */
+    container: UserPermissionsContainer
     /** Information object describing the user. */
     user: {
         /** The user's display name. */


### PR DESCRIPTION
#### Changes
* Fixes the type for the response from `Security.getUserPermissions`. User permissions appends additional information (e.g. `effectivePermissions`) that describe the user's permissions on the container.