### PR TITLE
Item 7095: Add detailed audit logging for samples as separate audit type event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 0.1.2 - 2020-04-15
 - Add optional auditBehavior parameter to IQueryRequestOptions 
 
 ## 0.1.1 - 2020-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Add optional auditLevel parameter to IQueryRequestOptions 
+
 ## 0.1.0 - 2020-04-06
 - Feature parity with clientapi_core.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## TBD - TBD
-- Add optional auditLevel parameter to IQueryRequestOptions 
+- Add optional auditBehavior parameter to IQueryRequestOptions 
 
 ## 0.1.1 - 2020-04-07
 - Fix for typings of Security.getUserPermissions response.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import { Query, Security } from '@labkey/api';
 
 ## Development
 
-If you would like to contribute changes to this package it is straight-forward to get setup for development. 
+If you would like to contribute changes to this package it is straightforward to get set up for development. 
 First, clone this repository to a directory
 
 ```sh
@@ -81,7 +81,7 @@ If installed correctly, `__package__` will contain package information such as t
 
 ## Publishing
 
-To publish, increment the version number in accordance with [SemVer](https://semver.org/), update the Readme.md, 
+To publish, increment the version number in accordance with [SemVer](https://semver.org/), update the CHANGELOG.md, 
 and commit. Then from the package root run
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.1.2-fb-sampleTimelineAuditEvents.3",
+  "version": "0.1.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.1.2-fb-sampleTimelineAuditEvents.1",
+  "version": "0.1.2-fb-sampleTimelineAuditEvents.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.1.2-fb-sampleTimelineAuditEvents.0",
+  "version": "0.1.2-fb-sampleTimelineAuditEvents.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.1.2-fb-sampleTimelineAuditEvents.2",
+  "version": "0.1.2-fb-sampleTimelineAuditEvents.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.1.0",
+  "version": "0.1.1-fb-sampleTimelineAuditEvents.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@
  */
 // constants
 import {
+    AuditBehaviorTypes,
     ExperimentalFeatures,
     LabKey,
     getServerContext,
@@ -49,6 +50,7 @@ import * as UtilsDOM from './labkey/dom/Utils';
 
 export {
     // constants
+    AuditBehaviorTypes,
     ExperimentalFeatures,
     LabKey,
     getServerContext,

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -61,6 +61,13 @@ export enum ExperimentalFeatures {
     strictReturnUrl = 'strictReturnUrl',
 }
 
+/** THe different types of audit behaviors for query requests. May be used to override behavior for a specific requests. */
+export enum AuditBehaviorTypes {
+    NONE = "NONE",
+    DETAILED = "DETAILED",
+    SUMMARY = "SUMMARY"
+}
+
 export type ExperimentalFlags = {
     [key in ExperimentalFeatures]: boolean
 }

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -18,6 +18,7 @@ import { IFilter } from '../filter/Filter'
 import { buildURL } from '../ActionURL'
 import { ExtendedXMLHttpRequest, getCallbackWrapper, getOnFailure, getOnSuccess, isArray } from '../Utils';
 import { buildQueryParams, ContainerFilter, getMethod, getSuccessCallbackWrapper } from './Utils'
+import { AuditBehaviorTypes } from '../constants';
 
 /**
  * Delete rows.
@@ -711,7 +712,8 @@ export interface IQueryRequestOptions {
     /** Whether all of the deletes should be done in a single transaction, so they all succeed or all fail. Defaults to true. */
     transacted?: boolean
 
-    auditLevel?: string
+    /** Can be used to override the audit behavior for the table the query is acting on. (@link LABKEY.AuditBehaviorTypes}) */
+    auditBehaviorType?: AuditBehaviorTypes
 }
 
 // Formerly sendJsonQueryRequest
@@ -731,7 +733,8 @@ function sendRequest(options: IQueryRequestOptions): XMLHttpRequest {
             queryName: options.queryName,
             rows: options.rows || options.rowDataArray,
             transacted: options.transacted,
-            extraContext: options.extraContext
+            extraContext: options.extraContext,
+            auditLevel: options.auditBehaviorType
         },
         timeout: options.timeout
     });

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -710,6 +710,8 @@ export interface IQueryRequestOptions {
 
     /** Whether all of the deletes should be done in a single transaction, so they all succeed or all fail. Defaults to true. */
     transacted?: boolean
+
+    auditLevel?: string
 }
 
 // Formerly sendJsonQueryRequest

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -712,7 +712,7 @@ export interface IQueryRequestOptions {
     /** Whether all of the deletes should be done in a single transaction, so they all succeed or all fail. Defaults to true. */
     transacted?: boolean
 
-    /** Can be used to override the audit behavior for the table the query is acting on. (@link LABKEY.AuditBehaviorTypes}) */
+    /** Can be used to override the audit behavior for the table the query is acting on. ({@link LABKEY.AuditBehaviorTypes}) */
     auditBehavior?: AuditBehaviorTypes
 }
 

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -713,7 +713,7 @@ export interface IQueryRequestOptions {
     transacted?: boolean
 
     /** Can be used to override the audit behavior for the table the query is acting on. (@link LABKEY.AuditBehaviorTypes}) */
-    auditBehaviorType?: AuditBehaviorTypes
+    auditBehavior?: AuditBehaviorTypes
 }
 
 // Formerly sendJsonQueryRequest
@@ -734,7 +734,7 @@ function sendRequest(options: IQueryRequestOptions): XMLHttpRequest {
             rows: options.rows || options.rowDataArray,
             transacted: options.transacted,
             extraContext: options.extraContext,
-            auditLevel: options.auditBehaviorType
+            auditBehavior: options.auditBehavior
         },
         timeout: options.timeout
     });


### PR DESCRIPTION
**Rationale**
For the sample timeline feature within LabKey Sample Manager, we require detailed audit logs for samples that can be more easily reference by sample Id.  We want to have this detailed audit logging turned on for Sample Manager without requiring that it be turned on for all Sample Types.

**Related PRs**
- https://github.com/LabKey/platform/pull/1060
- https://github.com/LabKey/labkey-ui-components/pull/220
- https://github.com/LabKey/sampleManagement/pull/235

**Changes**
- Add optional auditLevel parameter to IQueryRequestOptions 
