### PR TITLE
Module updates, fix Security.getSchemaPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1 - 2020-04-17
+- Module updates for `Exp`, `Message`, `Pipeline`, and `Report`.
+- Fix for `Security.getSchemaPermissions()` to defensively copy configuration for `getSecurableResources` call.
+
 ## 0.2.0 - 2020-04-15
 **ActionURL**
 - Fix container path encoding (match core behavior).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.1-fb-10-report.0",
+  "version": "0.2.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.0",
+  "version": "0.2.1-fb-10-report.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Exp.ts
+++ b/src/labkey/Exp.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 LabKey Corporation
+ * Copyright (c) 2019-2020 LabKey Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,15 @@
  */
 import { buildURL } from './ActionURL'
 import { request, RequestOptions } from './Ajax'
-import { ExtendedXMLHttpRequest, getCallbackWrapper, getOnFailure, getOnSuccess } from './Utils'
-import {create, DomainDesign, getDomainDetails, KINDS} from './Domain'
+import {
+    ExtendedXMLHttpRequest,
+    getCallbackWrapper,
+    getOnFailure,
+    getOnSuccess,
+    RequestFailure,
+    RequestSuccess
+} from './Utils'
+import { create, DomainDesign, getDomainDetails, KINDS } from './Domain'
 
 /**
  * The experiment object base class which describes basic characteristics of a protocol
@@ -568,12 +575,12 @@ export interface IDeleteRunOptions {
     /**
      * A reference to a function to call when an error occurs.
      */
-    failure?: () => any
+    failure?: RequestFailure
 
     /**
      * A reference to a function to call with the API results.
      */
-    success?: () => any
+    success?: RequestSuccess
 }
 
 /**
@@ -670,8 +677,8 @@ export class Run extends ExpObject {
      * Deletes the run from the database.
      * @param options
      */
-    deleteRun(options: IDeleteRunOptions): void {
-        request({
+    deleteRun(options: IDeleteRunOptions): XMLHttpRequest {
+        return request({
             url: buildURL('experiment', 'deleteRun.api'),
             method: 'POST',
             params: {

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -152,6 +152,7 @@ function createRuns(json: any): Run[] {
  * @ignore
  */
 export function exportRuns(config: any) {
+    // TODO: This needs to use DOMWrapper or be removed
     throw new Error('dom/Experiment.js required');
 }
 

--- a/src/labkey/Message.ts
+++ b/src/labkey/Message.ts
@@ -15,7 +15,7 @@
  */
 import { buildURL } from './ActionURL'
 import { request } from './Ajax'
-import { getCallbackWrapper, getOnFailure, getOnSuccess } from './Utils'
+import { getCallbackWrapper, getOnFailure, getOnSuccess, RequestCallbackOptions } from './Utils'
 
 export interface IMsgContent {
     content: string
@@ -23,7 +23,7 @@ export interface IMsgContent {
 }
 
 /**
- * A utility function to create a message content object used in sendMessage.
+ * A utility function to create a message content object used in [[sendMessage]].
  * @param type The content type of this message part
  * @param content The message part content.
  */
@@ -40,9 +40,9 @@ export interface IPrincipalRecipient {
 }
 
 /**
- * A utility function to create a recipient object (based on a user ID or group ID) used in LABKEY.Message.sendMessage.
+ * A utility function to create a recipient object (based on a user ID or group ID) used in [[sendMessage]].
  * Note: only server side validation or transformation scripts can specify a user or group ID.
- * @param [[RecipientType]] type Determines where the recipient email address will appear in the message.
+ * @param type Determines where the recipient email address will appear in the message.
  * @param principalId The user or group id of the recipient.
  */
 export function createPrincipalIdRecipient(type: RecipientType, principalId: number): IPrincipalRecipient {
@@ -58,7 +58,7 @@ export interface IRecipient {
 }
 
 /**
- * A utility function to create a recipient object used in sendMessage.
+ * A utility function to create a recipient object used in [[sendMessage]].
  * @param type Determines where the recipient email address will appear in the message.
  * @param address The email address of the recipient.
  */
@@ -101,8 +101,7 @@ export const recipientType: IRecipientTypeCollection = {
     to: 'TO'
 };
 
-export interface ISendMessageOptions {
-    failure?: () => any
+export interface ISendMessageOptions extends RequestCallbackOptions {
     /**
      * An array of content objects which have the following properties:
      * - type: the message content type, must be one of the values from: [[msgType]].
@@ -110,7 +109,7 @@ export interface ISendMessageOptions {
      *
      * The utility function [[createMsgContent]] can be used to help create these objects.
      */
-    msgContent?: Array<string>
+    msgContent?: string[]
     /** The email address that appears on the email from line. */
     msgFrom?: string
     /**
@@ -122,11 +121,9 @@ export interface ISendMessageOptions {
      * Recipients whose accounts have been deactivated or have never been logged into will be silently dropped from
      * the message.
      */
-    msgRecipients?: Array<string>
+    msgRecipients?: string[]
+    /** The value that appears on the email subject line. */
     msgSubject?: string
-    /** A scoping object for the success and error callback functions (default to this). */
-    scope?: any
-    success?: () => any
 }
 
 /**
@@ -134,7 +131,10 @@ export interface ISendMessageOptions {
  * must exist as valid accounts, or the current user account must have permission to send to addresses
  * not associated with a LabKey Server account at the site-level, or an error will be thrown.
  *
- * ```
+ * Recipients whose accounts have been deactivated or have never been logged into will be silently dropped from
+ * the message.
+ *
+ * ```js
  * function errorHandler(errorInfo, responseObj){
  *  LABKEY.Utils.displayAjaxErrorResponse(responseObj, errorInfo);
  * }

--- a/src/labkey/Utils.ts
+++ b/src/labkey/Utils.ts
@@ -430,7 +430,7 @@ export function generateUUID(): string {
  * primary callback function.
  */
 export function getCallbackWrapper<T = any>(
-    fn: Function, // TODO: Improve this type
+    fn: Function, // TODO: Improve this type -- (data: T, response: ExtendedXMLHttpRequest, options: RequestOptions) => any
     scope?: any,
     isErrorCallback?: boolean,
     responseTransformer?: (json?: any) => T


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1078 (version bump)

#### Changes
* Module updates for `Exp`, `Message`, `Pipeline`, and `Report`.
* Fix for `Security.getSchemaPermissions()` to defensively copy configuration for `getSecurableResources` call.