### PR TITLE
Query: requiredVersion handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.2 - 2020-04-20
+- Explicitly only support `[13.2, '13.2', 16.2, 17.1]` values for `requiredVersion` to process as a `Query.Response`.
+
 ## 0.2.1 - 2020-04-17
 - Module updates for `Exp`, `Message`, `Pipeline`, and `Report`.
 - Fix for `Security.getSchemaPermissions()` to defensively copy configuration for `getSecurableResources` call.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.2-fb-fix-req-version.0",
+  "version": "0.2.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.1",
+  "version": "0.2.2-fb-fix-req-version.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -379,21 +379,23 @@ export function getServerDate(options: RequestCallbackOptions<Date>): XMLHttpReq
     });
 }
 
+// TODO: Support for requiredVersion on the client-side needs to be improved.
+// We effectively support string | number, however, the user will receive different
+// response processing depending on if they used string | number (e.g. 17.1 vs "17.1" will be processed differently).
+const SUPPORTED_VERSIONS = [13.2, '13.2', 16.2, 17.1];
+
 export function getSuccessCallbackWrapper(
     onSuccess: Function,
     stripHiddenCols?: boolean,
     scope?: any,
     requiredVersion?: number | string
 ): AjaxHandler {
-    if (requiredVersion) {
-        const versionString = requiredVersion.toString();
-        if (versionString === '13.2' || versionString === '16.2' || versionString === '17.1') {
-            return getCallbackWrapper(function(data: any, response: ExtendedXMLHttpRequest, options: RequestOptions) {
-                if (data && onSuccess) {
-                    onSuccess.call(scope || this, new Response(data), response, options);
-                }
-            }, this);
-        }
+    if (SUPPORTED_VERSIONS.indexOf(requiredVersion) > -1) {
+        return getCallbackWrapper(function(data: any, response: ExtendedXMLHttpRequest, options: RequestOptions) {
+            if (data && onSuccess) {
+                onSuccess.call(scope || this, new Response(data), response, options);
+            }
+        }, this);
     }
 
     return getCallbackWrapper(function(data: any, response: ExtendedXMLHttpRequest, options: RequestOptions) {


### PR DESCRIPTION
#### Rationale
This PR makes client-side handling of the `Query` parameter `requiredVersion` consistent with what the core library is doing. To quote comment from code:

> TODO: Support for requiredVersion on the client-side needs to be improved. We effectively support string | number, however, the user will receive different response processing depending on if they used string | number (e.g. 17.1 vs "17.1" will be processed differently).

#### Changes
* Explicitly only support `[13.2, '13.2', 16.2, 17.1]` values for `requiredVersion` to process as a `Query.Response`.
* Add regression test coverage.
