### PR TITLE
Report.ts fix for populateParams() handling of inputParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## TBD - TBD
+- Report.ts fix for populateParams() handling of inputParams as key value pairs on the execParams object 
+    instead of as a nested object within it
+
 ## 0.2.2 - 2020-04-20
 - Explicitly only support `[13.2, '13.2', 16.2, 17.1]` values for `requiredVersion` to process as a `Query.Response`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 0.2.3 - 2020-04-24
 - Report.ts fix for populateParams() handling of inputParams as key value pairs on the execParams object 
     instead of as a nested object within it
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.2",
+  "version": "0.2.2-fb-reportPopulateParams.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.2-fb-reportPopulateParams.1",
+  "version": "0.2.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.2-fb-reportPopulateParams.0",
+  "version": "0.2.2-fb-reportPopulateParams.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Report.spec.ts
+++ b/src/labkey/Report.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as Ajax from './Ajax'
+
+import { execute } from './Report'
+
+describe('execute', () => {
+    it('should stringify "inputParams" object', () => {
+        // Arrange
+        const requestSpy = jest.spyOn(Ajax, 'request').mockImplementation();
+
+        // Act
+        execute({
+            reportId: 'db:123',
+            inputParams: {
+                x: 1,
+                y: 2,
+                z: 'foo'
+            }
+        });
+
+        // Assert
+        expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+            url: '/reports/execute.api',
+            method: 'POST',
+            jsonData: {
+                reportId: 'db:123',
+                'inputParams[x]': 1,
+                'inputParams[y]': 2,
+                'inputParams[z]': 'foo',
+            }
+        }));
+    });
+});

--- a/src/labkey/Report.ts
+++ b/src/labkey/Report.ts
@@ -100,8 +100,6 @@ export interface IRequestExecuteOptions extends RequestCallbackOptions<RequestEx
 export interface IRequestExecuteParams {
     /** The name of the function to execute */
     functionName?: string
-    /** An object with properties for input parameters. */
-    inputParams?: any
     /** Identifier for the report to execute */
     reportId?: string
     /** name of the report to execute if the id is unknown */
@@ -222,7 +220,7 @@ export function getSessions(options: IGetSessionsOptions): XMLHttpRequest {
  * @private
  */
 function populateParams(options: IRequestExecuteOptions, isReport: boolean): IRequestExecuteParams {
-    let execParams: IRequestExecuteParams = {};
+    let execParams: any = {};
 
     // fill in these parameters if we are executing a report
     if (isReport) {
@@ -255,11 +253,9 @@ function populateParams(options: IRequestExecuteOptions, isReport: boolean): IRe
 
     // bind client input params to our parameter map
     if (options.inputParams) {
-        execParams.inputParams = {};
-
         for (let i in options.inputParams) {
             if (options.inputParams.hasOwnProperty(i)) {
-                execParams.inputParams[i] = options.inputParams[i];
+                execParams["inputParams[" + i + "]"] = options.inputParams[i];
             }
         }
     }


### PR DESCRIPTION
#### Rationale
The medImmune module InvokePipeAnalysisTest failures showed a regression in the Report.ts populateParams() function with how it handles the inputParams. In the core/Report.js they are added to the object as key/value pairs like `inputParams[paramName]: "test"`. This changes goes back to the instead of putting those inputParams as a nested object.

#### Changes
* Revert Report.ts populateParams() handling of inputParams to put them as generated key/value pairs on the outer object instead of as a nested object.
