### PR TITLE
Experiment: support containerPath property, improve lineage types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.5 - 2020-04-28
+- Adds `containerPath` property to all `Experiment` module actions.
+- Improve typings for `Experiment.lineage()` and `Experiment.resolve()` return types.
+- Rename `Experiment` interfaces away from `I<Name>` pattern to `<Name>`.
+
 ## 0.2.4 - 2020-04-28
 - Module updates for 'Assay'.
 - Fix for `ActionURL.queryString()` to no longer parse functions as URL parameters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.5-fb-rungraph-deets.0",
+  "version": "0.2.5",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.4",
+  "version": "0.2.5-fb-rungraph-deets.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",


### PR DESCRIPTION
#### Rationale
This PR adds the `containerPath` property to all actions exported by the `Experiment` module. Additionally, the return type typings for `lineage()` and `resolve()` have been updated to more fully specify the object that is returned.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/237

#### Changes
* Adds `containerPath` property to all `Experiment` module actions.
* Improve typings for `Experiment.lineage()` and `Experiment.resolve()` return types.
* Rename interfaces away from `I<Name>` pattern to `<Name>`.