### PR TITLE
Export SelectDistinctOptions, SelectDistinctResponse, SelectRowsOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.7 - 2020-05-06
+- Export SelectDistinctOptions, SelectDistinctResponse, SelectRowsOptions
+
 ## 0.2.6 - 2020-05-05
 - Add EXP_LINEAGE_OF filter type
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.6",
+  "version": "0.2.7-fb-export-SelectDistinctOptions.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.7-fb-export-SelectDistinctOptions.0",
+  "version": "0.2.7",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Query.ts
+++ b/src/labkey/Query.ts
@@ -40,8 +40,8 @@ import {
     truncateTable,
     updateRows
 } from './query/Rows'
-import { selectDistinctRows } from './query/SelectDistinctRows'
-import { selectRows } from './query/SelectRows'
+import { SelectDistinctOptions, SelectDistinctResponse, selectDistinctRows } from './query/SelectDistinctRows'
+import { SelectRowsOptions, selectRows } from './query/SelectRows'
 import * as SQL from './query/experimental/SQL'
 import * as Visualization from './query/Visualization'
 import { Filter } from './filter/Filter'
@@ -76,7 +76,10 @@ export {
     Row,
     saveQueryViews,
     saveRows,
+    SelectDistinctOptions,
+    SelectDistinctResponse,
     selectDistinctRows,
+    SelectRowsOptions,
     selectRows,
     sqlDateLiteral,
     sqlDateTimeLiteral,

--- a/src/labkey/query/SelectDistinctRows.ts
+++ b/src/labkey/query/SelectDistinctRows.ts
@@ -26,7 +26,7 @@ export interface SelectDistinctResponse {
     values: any[]
 }
 
-export interface ISelectDistinctOptions extends RequestCallbackOptions<SelectDistinctResponse> {
+export interface SelectDistinctOptions extends RequestCallbackOptions<SelectDistinctResponse> {
     /**
      * A single column for which the distinct results will be requested.
      * This column must exist within the specified query.
@@ -89,7 +89,7 @@ export interface ISelectDistinctOptions extends RequestCallbackOptions<SelectDis
  * @hidden
  * @private
  */
-function buildSelectDistinctParams(options: ISelectDistinctOptions): any {
+function buildSelectDistinctParams(options: SelectDistinctOptions): any {
     let params = buildQueryParams(
         options.schemaName,
         options.queryName,
@@ -132,7 +132,7 @@ function buildSelectDistinctParams(options: ISelectDistinctOptions): any {
 /**
  * Select Distinct Rows
  */
-export function selectDistinctRows(options: ISelectDistinctOptions): XMLHttpRequest {
+export function selectDistinctRows(options: SelectDistinctOptions): XMLHttpRequest {
     if (!options.schemaName)
         throw 'You must specify a schemaName!';
     if (!options.queryName)

--- a/src/labkey/query/SelectRows.ts
+++ b/src/labkey/query/SelectRows.ts
@@ -22,7 +22,7 @@ import { buildQueryParams, ContainerFilter, getMethod, getSuccessCallbackWrapper
 
 export type ShowRows = 'all' | 'none' | 'paginated' | 'selected' | 'unselected';
 
-export interface ISelectRowsOptions extends RequestCallbackOptions {
+export interface SelectRowsOptions extends RequestCallbackOptions {
     /**
      * An Array of columns or a comma-delimited list of column names you wish to select from the specified query.
      * By default, selectRows will return the set of columns defined in the default value for this query, as defined
@@ -120,7 +120,7 @@ export interface ISelectRowsOptions extends RequestCallbackOptions {
  * @hidden
  * @private
  */
-function buildSelectRowsParams(options: ISelectRowsOptions): any {
+function buildSelectRowsParams(options: SelectRowsOptions): any {
 
     let params = buildQueryParams(
         options.schemaName,
@@ -199,7 +199,7 @@ function buildSelectRowsParams(options: ISelectRowsOptions): any {
  * @private
  * Provides backwards compatibility with pre-1.0 selectRows() argument configuration.
  */
-function selectRowArguments(args: IArguments): ISelectRowsOptions {
+function selectRowArguments(args: IArguments): SelectRowsOptions {
     return {
         schemaName: args[0],
         queryName: args[1],
@@ -242,7 +242,7 @@ function selectRowArguments(args: IArguments): ISelectRowsOptions {
  * for the async request that can be used to cancel the request. In server-side scripts,
  * this method will return the JSON response object (first parameter of the success or failure callbacks).
  */
-export function selectRows(options: ISelectRowsOptions): XMLHttpRequest {
+export function selectRows(options: SelectRowsOptions): XMLHttpRequest {
 
     if (arguments.length > 1) {
         options = selectRowArguments(arguments);


### PR DESCRIPTION
#### Rationale
Exporting these interfaces lets consumers get compile time safety when using our APIs.

#### Related Pull Requests
* No PR open yet, but related to, and needed by my fb_grid_parity branch on ui-components

#### Changes
- Remove I prefixes from ISelectDistinctOptions and ISelectRowsOptions, the prefixes are unnecessary.
- Export SelectDistinctOptions, SelectDistinctResponse, SelectRowsOptions
