### PR TITLE
material inputs, wire up protocol applications to the run correctly

### DIFF
--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -55,6 +55,10 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
      * Defaults to true.
      */
     transacted?: boolean
+    /**
+     * Experimental provenance information for APIs that support it
+     */
+    provenance?: any
 }
 
 /**
@@ -301,7 +305,8 @@ function sendRequest(options: SendRequestOptions): XMLHttpRequest {
             rows: options.rows || options.rowDataArray,
             transacted: options.transacted,
             extraContext: options.extraContext,
-            auditBehavior: options.auditBehavior
+            auditBehavior: options.auditBehavior,
+            provenance: options.provenance
         },
         timeout: options.timeout
     });


### PR DESCRIPTION
#### Rationale
To support tracking and linking provenance information across multiple API requests we are providing a way to pass provenance recording information into a subset of our query APIs.

#### Changes
* This is somewhat experimental, so for now we were not planning to document the exact shape of the provenance object so for now we were planning to just pass through any provenance JSON data.