### PR TITLE
Domain.getDomainDetails API support for domainKind parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Domain.getDomainDetails API support for domainKind parameter
+
 ## 0.2.8 - 2020-05-07
 - Module updates for `ParticipantGroup` and `Specimen`.
 - Utilize `RequestCallBackOptions` for option interfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 0.2.9 - 2020-05-22
 - Domain.getDomainDetails API support for domainKind parameter
 
 ## 0.2.8 - 2020-05-07

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.8-fb-domainDesignersIssue40347.0",
+  "version": "0.2.9",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.8",
+  "version": "0.2.8-fb-domainDesignersIssue40347.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Domain.ts
+++ b/src/labkey/Domain.ts
@@ -236,7 +236,10 @@ export interface GetDomainDetailsResponse {
 }
 
 export interface GetDomainDetailsOptions extends
-    BaseGetDomainOptions, RequestCallbackOptions<GetDomainDetailsResponse> { }
+    BaseGetDomainOptions, RequestCallbackOptions<GetDomainDetailsResponse> {
+    /** The domain kind, used for the create domain case when you want to get the details/options for the given domain kind. */
+    domainKind?: string
+}
 
 /**
  * Gets a domain design.
@@ -281,7 +284,8 @@ export function getDomainDetails(config: GetDomainDetailsOptions): XMLHttpReques
         params: {
             schemaName: options.schemaName,
             queryName: options.queryName,
-            domainId: options.domainId
+            domainId: options.domainId,
+            domainKind: options.domainKind
         }
     });
 }


### PR DESCRIPTION
#### Rationale
Issue [40347](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40347): Domain designer wrappers not supporting domain kind specific properties in the create case. Allow for calls to Domain.getDomainDetails to pass in a domainKind param to get domain kind specific properties. This allows for the create case for each domain designer to use the domain kind specific options in the DomainForm components (i.e. fields panel).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1122
* https://github.com/LabKey/labkey-ui-components/pull/248

#### Changes
* Add domainKind param to GetDomainDetailsOptions and use in params for getDomainDetails API call
