### PR TITLE
Introduce "App" module registerApp / loadApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0 - 2020-06-04
+- Introduce "App" module `registerApp` / `loadApp`
+
 ## 0.2.9 - 2020-05-22
 - Domain.getDomainDetails API support for domainKind parameter
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.2.9",
+  "version": "0.3.0-fb-register-apps.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.0-fb-register-apps.0",
+  "version": "0.3.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
 // modules
 import * as ActionURL from './labkey/ActionURL';
 import * as Ajax from './labkey/Ajax';
+import * as App from './labkey/App';
 import * as Assay from './labkey/Assay';
 import * as Domain from './labkey/Domain';
 import * as Exp from './labkey/Exp';
@@ -58,6 +59,7 @@ export {
     // modules
     ActionURL,
     Ajax,
+    App,
     Assay,
     AssayDOM,
     Domain,

--- a/src/labkey/App.ts
+++ b/src/labkey/App.ts
@@ -1,0 +1,129 @@
+type OnInitCallback<CTX> = (target: string, ctx: CTX) => void;
+
+interface AppRegistryItem<CTX = any> {
+    appName: string;
+    contexts: CTX[];
+    hot: boolean;
+    onInit: OnInitCallback<CTX>;
+    targets: string[];
+}
+
+type AppRegistry = {
+    isDOMContentLoaded: boolean;
+    registry: { [appName: string]: AppRegistryItem };
+};
+
+/**
+ * @hidden
+ * @private
+ */
+declare const LABKEY: any;
+
+/**
+ * Returns the App registry shared across all "instances" of @labkey/api.
+ * @hidden
+ * @private
+ */
+function getRegistry(): AppRegistry {
+    if (!LABKEY.App.__app__) {
+        throw new Error('App registry not initialized. Must call init() prior to getRegistry()');
+    }
+    return LABKEY.App.__app__;
+}
+
+/**
+ * Attaches the App registry to a global namespace. This registry must be shared across
+ * "instances" of @labkey/api so this method is defensive against subsequent calls.
+ * @hidden
+ * @private
+ */
+export function init(LABKEY: any) {
+    // Hook loadApp and prepare global registry shared across apps
+    if (LABKEY?.App) {
+        // Defensively avoid redundant calls to init()
+        if (!LABKEY.App.__app__) {
+            LABKEY.App.__app__ = {
+                isDOMContentLoaded: false,
+                registry: {},
+            };
+        }
+    } else {
+        console.log('LABKEY.App is not available. Unable to initialize application registry.');
+    }
+}
+
+/**
+ * Load/initialize applications that are registered via [[registerApp]].
+ * @param appName
+ * @param appTarget
+ * @param appContext
+ */
+export function loadApp<CTX = any>(appName: string, appTarget: string, appContext: CTX): void {
+    const appRegistry = getRegistry();
+
+    if (appRegistry.registry.hasOwnProperty(appName)) {
+        if (appRegistry.registry[appName].hot) {
+            appRegistry.registry[appName].contexts.push(appContext);
+            appRegistry.registry[appName].targets.push(appTarget);
+        }
+
+        if (appRegistry.isDOMContentLoaded) {
+            appRegistry.registry[appName].onInit(appTarget, appContext);
+        } else {
+            window.addEventListener(
+                'DOMContentLoaded',
+                () => {
+                    appRegistry.isDOMContentLoaded = true;
+                    appRegistry.registry[appName].onInit(appTarget, appContext);
+                },
+                { once: true }
+            );
+        }
+    } else {
+        throw Error(`Application "${appName}" is not a registered application. Unable to initialize.`);
+    }
+}
+
+/**
+ * Registers an app by "appName". When the app is requested to be loaded (via [[loadApp]]) the onInit()
+ * callback will be invoked to initialize the app.
+ * @param appName The unique name for this app type.
+ * @param onInit Callback that will be invoked when the app is loaded.
+ * @param hot If this app is running in a "hot" module reload context you'll want to set this to "true" so the
+ * app can be properly initialized after module reloads.
+ */
+export function registerApp<CTX>(appName: string, onInit: OnInitCallback<CTX>, hot?: boolean): void {
+    const appRegistry = getRegistry();
+
+    if (!appRegistry.registry.hasOwnProperty(appName)) {
+        appRegistry.registry[appName] = {
+            appName,
+            contexts: [],
+            hot: hot === true,
+            onInit,
+            targets: [],
+        };
+    } else if (appRegistry.registry[appName].hot) {
+        runHot(appRegistry.registry[appName]);
+    }
+}
+
+/**
+ * @hidden
+ * @private
+ */
+function runHot(item: AppRegistryItem): void {
+    if (!item.hot) {
+        throw Error(`Attempting to run application ${item.appName} hot when hot is not enabled.`);
+    }
+
+    if (item.targets.length !== item.contexts.length) {
+        throw Error(
+            `Application registry for "${item.appName}" is in an invalid state. Expected targets and contexts to align.`
+        );
+    }
+
+    for (let i = 0; i < item.targets.length; i++) {
+        item.onInit(item.targets[i], item.contexts[i]);
+    }
+}

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -29,6 +29,7 @@ declare let LABKEY: any;
 
 LABKEY.ActionURL = API.ActionURL;
 LABKEY.Ajax = API.Ajax;
+LABKEY.App = API.App;
 LABKEY.Assay = API.Assay;
 LABKEY.Domain = API.Domain;
 LABKEY.Exp = API.Exp;
@@ -49,3 +50,6 @@ LABKEY.Specimen = API.Specimen;
 LABKEY.Utils = API.Utils;
 LABKEY.Visualization = API.Visualization;
 LABKEY.__package__ = __package__;
+
+// The app registry needs to be initialized after the namespace has been established.
+API.App.init(LABKEY);


### PR DESCRIPTION
### Rationale
Building and running React apps in LKS is steadily growing as our feature development with React continues to grow. There are a couple of challenges this PR seeks to address:

1. Allowing DOM context (e.g. target element) to be passed to the application upon render.
1. Capturing server context/data without additional requests.

#### Approach

We want to support loading React apps into our variety of different view-generation options. This includes module views, JSP's, and webparts. Up until this point our apps have utilized only the module views approach.

This PR introduces a couple of mechanisms that work together to allow for loading/declaring apps. They are:

- Registering apps. Applications are registered and are made available to be loaded.
- Loading apps. Applications can be requested to be loaded with a specific DOM and custom server context.

#### Registering an App

`registerApp` is a new method that wraps the initialization of a React application at the highest level. When an app is loaded the callback (i.e. `onInit`) will be invoked allowing for the app to render it's contents to the DOM. The `onInit` callback is supplied two parameters

Here is an example of how an app is registered in both the production and dev/watch variants:
```tsx
// app.tsx
import { App } from '@labkey/api';
import { AppContext, MyApp } from './MyApp';

App.registerApp<AppContext>('myApp', (target: string, ctx: AppContext) => {
    ReactDOM.render(<MyApp context={ctx} />, document.getElementById(target));
});

// dev.tsx
import { AppContainer } from 'react-hot-loader';

App.registerApp<AppContext>('myApp', (target: string, ctx: AppContext) => {
    ReactDOM.render(
        <AppContainer>
            <MyApp context={ctx} />
        </AppContainer>,
        document.getElementById(target)
    );
}, true /* hot */);
```

#### Loading an App

Once an app has been registered and the assets included (e.g. via client dependency management) then it is eligible to be loaded in that view. `loadApp` is a method which is hooked up by this package to the global `LABKEY` namespace.

Here is an example of how an app is loaded via a `.jsp`:

```jsp
<div id="<%=h(appId)%>"></div>

var target = <%=q(appId)%>;

LABKEY.App.loadApp('myApp', target, {
    custom: 'prop',
    another: 'customProp',
});
```

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/263
* https://github.com/LabKey/platform/pull/1262

#### Changes
* Add a new module named "App" which exposes `registerApp` and `loadApp` methods.
* Initialize global app registry.
