### PR TITLE
Item 7373: Add "project" and "WebSocket" to LabKey typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 0.3.1 - 2020-06-05
 - Item 7373: Add "project" and "WebSocket" to LabKey typing, which will allow for main.d.ts file overrides to be removed in a few modules
 
 ## 0.3.0 - 2020-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Item 7373: Add "project" and "WebSocket" to LabKey typing, which will allow for main.d.ts file overrides to be removed in a few modules
+
 ## 0.3.0 - 2020-06-04
 - Introduce "App" module `registerApp` / `loadApp`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.0",
+  "version": "0.3.0-fb-fmAppSetupPlaceholders.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.0-fb-fmAppSetupPlaceholders.0",
+  "version": "0.3.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -52,6 +52,17 @@ export interface Container {
     type: string
 }
 
+export interface Project {
+    /** GUID of this project. */
+    id: string
+    /** Name of the project. This is used in the project's container path. */
+    name: string
+    /** Path of this project. */
+    path: string
+    /** GUID of the root container, which is the parent for the project. */
+    rootId: string
+}
+
 export enum ExperimentalFeatures {
     containerRelativeURL = 'containerRelativeURL',
     disableGuestAccount = 'disableGuestAccount',
@@ -91,6 +102,7 @@ export type LabKey = {
     moduleContext: any
     Mothership: any
     postParameters?: any
+    project: Project
     requiresCss?: Function
     requiresScript: Function
     Security: any
@@ -103,6 +115,7 @@ export type LabKey = {
     uuids: Array<string>
     verbose: boolean
     vis: any
+    WebSocket: any
 }
 
 export interface User {


### PR DESCRIPTION
#### Rationale
There are two remaining properties of the LabKey typing that are missing before we can remove the overrides to this type that lives in the SM and FM app main.d.ts files. This PR adds them which will allow for main.d.ts file overrides to be removed.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/265
* https://github.com/LabKey/sampleManagement/pull/286
* https://github.com/LabKey/inventory/pull/34

#### Changes
* Add "project" and "WebSocket" to LabKey typing
