### PR TITLE
Add Security.getUsersWithPermissions, export Container/User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.2 - 2020-06-08
+* Add `Security.getUsersWithPermissions()` which shares parameter parsing with `Security.getUsers()` 
+as they share payload processing on the server.
+* Split `User` interface into `User` and `UserWithPermissions` to better model server response shapes.
+* Publically export `Container`, `User`, and `UserWithPermissions` interfaces.
+* Migrated `PermissionTypes` from `@labkey/components` and switched it to an enum. Deprecated `effectivePermissions` 
+that was previously declared.
+
 ## 0.3.1 - 2020-06-05
 - Item 7373: Add "project" and "WebSocket" to LabKey typing, which will allow for main.d.ts file overrides to be removed in a few modules
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.2-fb-user-with-permissions.1",
+  "version": "0.3.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.1",
+  "version": "0.3.2-fb-user-with-permissions.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.2-fb-user-with-permissions.0",
+  "version": "0.3.2-fb-user-with-permissions.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import {
     UserWithPermissions,
 } from './labkey/constants';
 
+import { PermissionTypes } from './labkey/Security/constants';
+
 // modules
 import * as ActionURL from './labkey/ActionURL';
 import * as Ajax from './labkey/Ajax';
@@ -59,6 +61,7 @@ export {
     ExperimentalFeatures,
     LabKey,
     getServerContext,
+    PermissionTypes,
     User,
     UserWithPermissions,
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import {
     UserWithPermissions,
 } from './labkey/constants';
 
-import { PermissionTypes } from './labkey/Security/constants';
+import { PermissionTypes } from './labkey/security/constants';
 
 // modules
 import * as ActionURL from './labkey/ActionURL';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,7 @@ import {
     LabKey,
     getServerContext,
     User,
-    UserPermissionsProps,
-    UserProps,
+    UserWithPermissions,
 } from './labkey/constants';
 
 // modules
@@ -61,8 +60,7 @@ export {
     LabKey,
     getServerContext,
     User,
-    UserPermissionsProps,
-    UserProps,
+    UserWithPermissions,
 
     // modules
     ActionURL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,13 @@
 // constants
 import {
     AuditBehaviorTypes,
+    Container,
     ExperimentalFeatures,
     LabKey,
     getServerContext,
+    User,
+    UserPermissionsProps,
+    UserProps,
 } from './labkey/constants';
 
 // modules
@@ -52,9 +56,13 @@ import * as UtilsDOM from './labkey/dom/Utils';
 export {
     // constants
     AuditBehaviorTypes,
+    Container,
     ExperimentalFeatures,
     LabKey,
     getServerContext,
+    User,
+    UserPermissionsProps,
+    UserProps,
 
     // modules
     ActionURL,

--- a/src/labkey/Security.ts
+++ b/src/labkey/Security.ts
@@ -45,7 +45,8 @@ import {
 import {
     createNewUser,
     ensureLogin,
-    getUsers
+    getUsers,
+    getUsersWithPermissions
 } from './security/User'
 import {
     addGroupMembers,
@@ -94,6 +95,7 @@ export {
     getSharedContainer,
     getUserPermissions,
     getUsers,
+    getUsersWithPermissions,
     hasEffectivePermission,
     hasPermission,
     moveContainer,

--- a/src/labkey/Security.ts
+++ b/src/labkey/Security.ts
@@ -17,6 +17,7 @@ import {
     currentContainer,
     currentUser,
     effectivePermissions,
+    PermissionTypes,
     permissions,
     roles,
     systemGroups
@@ -67,6 +68,7 @@ export {
     currentContainer,
     currentUser,
     effectivePermissions,
+    PermissionTypes,
     permissions,
     roles,
     systemGroups,

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -124,6 +124,8 @@ export interface User {
     displayName: string
     id: number
     phone: string
+    // Some LabKey Server API responses specify "userId" in addition to "id" when serializing a User response.
+    // This will not always be available but is made available in the typings for ease of use of this interface.
     userId?: number
 }
 

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -111,22 +111,23 @@ export type LabKey = {
     submit: boolean
     unloadMessage: string
     useMDYDateParsing?: boolean
-    user: Partial<User>
+    user: Partial<UserWithPermissions>
     uuids: Array<string>
     verbose: boolean
     vis: any
     WebSocket: any
 }
 
-export interface UserProps {
+export interface User {
     avatar: string
     email: string
     displayName: string
     id: number
     phone: string
+    userId?: number
 }
 
-export interface UserPermissionsProps {
+export interface UserWithPermissions extends User {
     canDelete: boolean
     canDeleteOwn: boolean
     canInsert: boolean
@@ -142,8 +143,6 @@ export interface UserPermissionsProps {
     isTrusted: boolean
 }
 
-export type User = UserProps & UserPermissionsProps;
-
 declare let LABKEY: LabKey;
 
 export function getLocation(): Location {
@@ -154,7 +153,7 @@ export function getServerContext(): LabKey {
     return LABKEY;
 }
 
-export function setGlobalUser(user: User): LabKey {
+export function setGlobalUser(user: UserWithPermissions): LabKey {
     LABKEY.user = user;
     return LABKEY;
 }

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -118,16 +118,20 @@ export type LabKey = {
     WebSocket: any
 }
 
-export interface User {
+export interface UserProps {
     avatar: string
     email: string
+    displayName: string
+    id: number
+    phone: string
+}
+
+export interface UserPermissionsProps {
     canDelete: boolean
     canDeleteOwn: boolean
     canInsert: boolean
     canUpdate: boolean
     canUpdateOwn: boolean
-    displayName: string
-    id: number
     isAdmin: boolean
     isAnalyst: boolean
     isDeveloper: boolean
@@ -136,8 +140,9 @@ export interface User {
     isSignedIn: boolean
     isSystemAdmin: boolean
     isTrusted: boolean
-    phone: string
 }
+
+export type User = UserProps & UserPermissionsProps;
 
 declare let LABKEY: LabKey;
 

--- a/src/labkey/security/User.ts
+++ b/src/labkey/security/User.ts
@@ -146,20 +146,13 @@ export function ensureLogin(config: EnsureLoginOptions): XMLHttpRequest | void {
     }
 }
 
-export interface GetUsersUser {
-    /** The user's display name. */
-    displayName: string
-    /** The user's email address. */
-    email: string
-    /** The user's userId. */
-    userId: number
-}
-
 export interface GetUsersResponse {
     /** The path of the requested container. */
     container: string
+    /** If "name" property is specified on request, then it's value will be included in the response. */
+    name?: string
     /** An array of users matching the request criteria. */
-    users: GetUsersUser[]
+    users: User[]
 }
 
 export interface GetUsersOptions extends RequestCallbackOptions<GetUsersResponse> {
@@ -197,6 +190,37 @@ export interface GetUsersOptions extends RequestCallbackOptions<GetUsersResponse
  * (first parameter of the success or failure callbacks.)
  */
 export function getUsers(config: GetUsersOptions): XMLHttpRequest {
+    return getUsersRequest('getUsers.api', config);
+}
+
+export interface GetUsersWithPermissionsOptions extends GetUsersOptions {
+    /**
+     * A permissions string or an Array of permissions strings.
+     * If multiple permissions are specified, then all returned users will have all specified permissions.
+     */
+    permissions: string | string[]
+}
+
+/**
+ * Retrieves the set of users that have all of a specified set of permissions.  A group
+ * may be provided and only users within that group will be returned.  A name (prefix) may be
+ * provided and only users whose email or display name starts with the prefix will be returned.
+ * This will not return any deactivated users (since they do not have permissions of any sort).
+ *
+ * @returns {Mixed} In client-side scripts, this method will return a transaction id
+ * for the async request that can be used to cancel the request.
+ * In server-side scripts, this method will return the JSON response object
+ * (first parameter of the success or failure callbacks.)
+ */
+export function getUsersWithPermissions(config: GetUsersWithPermissionsOptions): XMLHttpRequest {
+    return getUsersRequest('getUsersWithPermissions.api', config);
+}
+
+/**
+ * @hidden
+ * @private
+ */
+function getUsersRequest(endpoint: string, config: GetUsersOptions): XMLHttpRequest {
     let params: any = {};
 
     // TODO: These undefined checked should be !==
@@ -207,7 +231,7 @@ export function getUsers(config: GetUsersOptions): XMLHttpRequest {
         params.group = config.group;
     }
 
-    if (config.name != undefined) {
+    if (config.name) {
         params.name = config.name;
     }
 
@@ -229,9 +253,9 @@ export function getUsers(config: GetUsersOptions): XMLHttpRequest {
     }
 
     return request({
-        url: buildURL('user', 'getUsers.api', config.containerPath),
+        url: buildURL('user', endpoint, config.containerPath),
         params,
         success: getCallbackWrapper(getOnSuccess(config), config.scope),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true)
-    })
+    });
 }

--- a/src/labkey/security/constants.ts
+++ b/src/labkey/security/constants.ts
@@ -16,37 +16,40 @@
 import { getServerContext } from '../constants'
 
 /**
- * Exposes limited information about the current container. This property returns a JavaScript object
- * with the following properties:
- * <ul>
- * <li>id: the container's unique id (entityid)</li>
- * <li>name: the name of the container</li>
- * <li>path: the path of the current container</li>
- * <li>type: the type of container, either project, folder or workbook</li>
- * </ul>
+ * Exposes limited information about the current container.
  */
 export const currentContainer = getServerContext().container;
 
 /**
- * Exposes limited information about the current user. This property returns a JavaScript object
- * with the following properties:
- * <ul>
- * <li>id: the user's unique id number</li>
- * <li>displayName: the user's display name</li>
- * <li>email: the user's email address</li>
- * <li>canInsert: set to true if this user can insert data in the current folder</li>
- * <li>canUpdate: set to true if this user can update data in the current folder</li>
- * <li>canUpdateOwn: set to true if this user can update data this user created in the current folder</li>
- * <li>canDelete: set to true if this user can delete data in the current folder</li>
- * <li>canDeleteOwn: set to true if this user can delete data this user created in the current folder</li>
- * <li>isAdmin: set to true if this user has admin permissions in the current folder</li>
- * <li>isGuest: set to true if this user is the guest (anonymous) user</li>
- * <li>isSystemAdmin: set to true if this user is a system administrator</li>
- * <li>isDeveloper: set to true if this user is a developer</li>
- * <li>isSignedIn: set to true if this user is signed in</li>
- * </ul>
+ * Exposes limited information about the current user.
  */
 export const currentUser = getServerContext().user;
+
+/**
+ * An enumeration of commonly used permission types supported in LabKey Server.
+ * This can be used in conjunction with the hasEffectivePermission() method to test if
+ * a user or group has a particular permission.
+ */
+export enum PermissionTypes {
+    // CRUD
+    Admin = 'org.labkey.api.security.permissions.AdminPermission',
+    Delete = 'org.labkey.api.security.permissions.DeletePermission',
+    Insert = 'org.labkey.api.security.permissions.InsertPermission',
+    Read = 'org.labkey.api.security.permissions.ReadPermission',
+    Update = 'org.labkey.api.security.permissions.UpdatePermission',
+
+    // Other
+    ApplicationAdmin = 'org.labkey.api.security.permissions.ApplicationAdminPermission',
+    DesignAssay = 'org.labkey.api.assay.security.DesignAssayPermission',
+    DesignDataClass = 'org.labkey.api.security.permissions.DesignDataClassPermission',
+    DesignList = 'org.labkey.api.lists.permissions.DesignListPermission',
+    DesignSampleSet = 'org.labkey.api.security.permissions.DesignSampleSetPermission',
+    ReadSome = 'org.labkey.api.security.permissions.ReadSomePermission',
+    UserManagement = 'org.labkey.api.security.permissions.UserManagementPermission',
+
+    // Assay QC
+    QCAnalyst = 'org.labkey.api.security.permissions.QCAnalystPermission',
+}
 
 /**
  * A map of commonly used effective permissions supported in the LabKey Server.
@@ -60,16 +63,17 @@ export const currentUser = getServerContext().user;
  * <li>del</li>
  * <li>readOwn</li>
  * </ul>
+ * @deprecated Use [[PermissionTypes]] instead.
  * For example, to refer to the update permission, the syntax would be:<br/>
  * <pre><code>LABKEY.Security.effectivePermissions.update</code></pre>
  */
 export const effectivePermissions = {
-    insert: 'org.labkey.api.security.permissions.InsertPermission',
-    read: 'org.labkey.api.security.permissions.ReadPermission',
-    admin: 'org.labkey.api.security.permissions.AdminPermission',
-    del: 'org.labkey.api.security.permissions.DeletePermission',
-    readOwn: 'org.labkey.api.security.permissions.ReadSomePermission',
-    update: 'org.labkey.api.security.permissions.UpdatePermission'
+    insert: PermissionTypes.Insert,
+    read: PermissionTypes.Read,
+    admin: PermissionTypes.Admin,
+    del: PermissionTypes.Delete,
+    readOwn: PermissionTypes.ReadSome,
+    update: PermissionTypes.Update,
 };
 
 /**


### PR DESCRIPTION
#### Rationale
Create client-side wrapper for `user-getUserWithPermissions.api` in `@labkey/api`. Additionally, export `Container`, `User`, and `UserWithPermissions` as public interfaces.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/269
* https://github.com/LabKey/platform/pull/1282

#### Changes
* Add `Security.getUsersWithPermissions()` which shares parameter parsing with `Security.getUsers()` as they share payload processing on the server.
* Split `User` interface into `User` and `UserWithPermissions` to better model server response shapes.
* Publically export `Container`, `User`, and `UserWithPermissions` interfaces.
* Migrated `PermissionTypes` from `@labkey/components` and switched it to an enum. Deprecated `effectivePermissions` that was previously declared.
