### PR TITLE
getFiltersFromParameters: Use Object.keys instead of "key in obj".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.4 - 2020-07-??
+## 0.3.4 - 2020-07-07
 - getFiltersFromParameters: Use Object.keys instead of "for(paramName in params)".
 
 ## 0.3.3 - 2020-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
+## 0.3.4 - 2020-07-??
+- getFiltersFromParameters: Use Object.keys instead of "for(paramName in params)".
+
 ## 0.3.3 - 2020-06-16
 - Package updates.
 
 ## 0.3.2 - 2020-06-08
-* Add `Security.getUsersWithPermissions()` which shares parameter parsing with `Security.getUsers()` 
+- Add `Security.getUsersWithPermissions()` which shares parameter parsing with `Security.getUsers()` 
 as they share payload processing on the server.
-* Split `User` interface into `User` and `UserWithPermissions` to better model server response shapes.
-* Publically export `Container`, `User`, and `UserWithPermissions` interfaces.
-* Migrated `PermissionTypes` from `@labkey/components` and switched it to an enum. Deprecated `effectivePermissions` 
+- Split `User` interface into `User` and `UserWithPermissions` to better model server response shapes.
+- Publically export `Container`, `User`, and `UserWithPermissions` interfaces.
+- Migrated `PermissionTypes` from `@labkey/components` and switched it to an enum. Deprecated `effectivePermissions` 
 that was previously declared.
 
 ## 0.3.1 - 2020-06-05

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.3",
+  "version": "0.3.4-fb-fix-getFiltersFromParameters.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "0.3.4-fb-fix-getFiltersFromParameters.0",
+  "version": "0.3.4",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/filter/Filter.ts
+++ b/src/labkey/filter/Filter.ts
@@ -254,32 +254,29 @@ export function getFiltersFromParameters(params: {[key:string]: any}, dataRegion
     let filters: Array<IFilter> = [];
     const regionName = ensureRegionName(dataRegionName);
 
-    for (const paramName in params) {
-        if (params.hasOwnProperty(paramName)) {
-            // Look for parameters that have the right prefix
-            if (paramName.indexOf(regionName + '.') == 0) {
-                let tilde = paramName.indexOf('~');
+    Object.keys(params).forEach(paramName => {
+        if (paramName.indexOf(regionName + '.') == 0) {
+            let tilde = paramName.indexOf('~');
 
-                if (tilde != -1) {
-                    let columnName = paramName.substring(regionName.length + 1, tilde);
-                    let filterName = paramName.substring(tilde + 1);
-                    let filterType = getFilterTypeForURLSuffix(filterName);
+            if (tilde != -1) {
+                let columnName = paramName.substring(regionName.length + 1, tilde);
+                let filterName = paramName.substring(tilde + 1);
+                let filterType = getFilterTypeForURLSuffix(filterName);
 
-                    let values = params[paramName];
-                    // Create separate Filter objects if the filter parameter appears on the URL more than once.
-                    if (isArray(values)) {
-                        for (let i = 0; i < values.length; i++) {
-                            filters.push(create(columnName, values[i], filterType));
-                        }
+                let values = params[paramName];
+                // Create separate Filter objects if the filter parameter appears on the URL more than once.
+                if (isArray(values)) {
+                    for (let i = 0; i < values.length; i++) {
+                        filters.push(create(columnName, values[i], filterType));
                     }
-                    else {
-                        filters.push(create(columnName, values, filterType));
-                    }
-
                 }
+                else {
+                    filters.push(create(columnName, values, filterType));
+                }
+
             }
         }
-    }
+    });
 
     return filters;
 }


### PR DESCRIPTION
## Rationale
We are using this method in Biologics with React Router which provides us query params objects that have a null prototype, so they do not have any methods like hasOwnProperty.

#### Related Pull Requests
* n/a - will have PRs open in ui-components and biologics (branch name fb_url_binding) in the near future, though this can be merged before they are opened.

#### Changes
* getFiltersFromParameters: Use Object.keys instead of "for(paramName in params)".
