### PR TITLE
Item 7514: Allow users to attach comments for the audit log when inserting, updating, or deleting rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Add optional auditUserComment parameter to request objects for inclusion in some audit log records
+
 ## 1.0.2 - 2020-08-07
 - Clean-up distribution
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.1.0 - 2020-08-27
 - Add optional auditUserComment parameter to request objects for inclusion in some audit log records
 
 ## 1.0.2 - 2020-08-07

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.0.3-fmCheckInAndOut.0",
+  "version": "1.1.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.0.2",
+  "version": "1.0.3-fmCheckInAndOut.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -22,7 +22,7 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
     apiVersion?: number | string
     /** Can be used to override the audit behavior for the table the query is acting on. See [[AuditBehaviorTypes]]. */
     auditBehavior?: AuditBehaviorTypes
-    /** Can be used to provide a comment from the user that will be attached to certain detailed audit logs. */
+    /** Can be used to provide a comment from the user that will be attached to certain detailed audit log records. */
     auditUserComment?: string
     /**
      * The container path in which the schema and query name are defined.

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -22,6 +22,8 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
     apiVersion?: number | string
     /** Can be used to override the audit behavior for the table the query is acting on. See [[AuditBehaviorTypes]]. */
     auditBehavior?: AuditBehaviorTypes
+    /** Can be used to provide a comment from the user that will be attached to certain detailed audit logs. */
+    auditUserComment?: string
     /**
      * The container path in which the schema and query name are defined.
      * If not supplied, the current container path will be used.
@@ -301,7 +303,8 @@ function sendRequest(options: SendRequestOptions): XMLHttpRequest {
             rows: options.rows || options.rowDataArray,
             transacted: options.transacted,
             extraContext: options.extraContext,
-            auditBehavior: options.auditBehavior
+            auditBehavior: options.auditBehavior,
+            auditUserComment: options.auditUserComment
         },
         timeout: options.timeout
     });


### PR DESCRIPTION
#### Rationale
When checking items in and out of the freezer, we want to allow users to optionally provide comments on the action. These comments are naturally associated with the audit event, not with the sample or the inventory item, so we provide a parameter in the request for attaching the user comments that can then be passed through to the methods for creating the audit events. They are to be surfaced with the sample timeline and inventory location history views within the applications.

Though these comments are currently only surface within the LKSM and LKFM applications, it seems a generally useful functionality to be able to comment on audit events.  We may in the future decide to make a richer feature set around comments and audit logs, but for now this serves as a good starting point for our initial use case.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1512

#### Changes
* Add optional `auditUserComment` parameter to request payload
