### PR TITLE
Remove unnecessary 'test_teamcity' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "prepublishOnly": "npm run build",
     "deploy": "gh-pages -t -d docs",
     "setup": "npm install",
-    "test": "cross-env NODE_ENV=test jest",
-    "test_teamcity": "cross-env NODE_ENV=test jest --testResultsProcessor=jest-teamcity-reporter"
+    "test": "cross-env NODE_ENV=test jest"
   },
   "keywords": [
     "labkey",
@@ -69,6 +68,7 @@
       "js"
     ],
     "preset": "ts-jest",
+    "testResultsProcessor": "jest-teamcity-reporter",
     "testRegex": "(\\.(spec))\\.(ts)$"
   }
 }


### PR DESCRIPTION
#### Rationale
`jest-teamcity-reporter` does nothing when not running on TeamCity

#### Changes
* Move `testResultsProcessor` to jest configuration.
* Remove unnecessary `teat_teamcity` script.
