### PR TITLE
Fix MultiRequest to return instance. Add unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.# - 2020-12-##
+- [41969](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41969): Fix MultiRequest to return instance. Add unit tests.
+
 ## 1.1.1 - 2020-09-18
 - Add additional properties exposed via `getServerContext()` to typings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.# - 2020-12-##
+## 1.1.2 - 2020-12-09
 - [41969](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41969): Fix MultiRequest to return instance. Add unit tests.
 
 ## 1.1.1 - 2020-09-18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/MultiRequest.spec.ts
+++ b/src/labkey/MultiRequest.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MultiRequest } from './MultiRequest';
+
+describe('MultiRequest', () => {
+    it('handles array of requests and add', (done) => {
+        // Arrange
+        const scope = {};
+        let sum = 0;
+        function asyncMethod(config: any) {
+            sum += config.x;
+            setTimeout(config.success, config.timeout);
+        }
+
+        const requests = [
+            [ asyncMethod, { x: 1, timeout: 25 } ],
+            [ asyncMethod, { x: 2, timeout: 50 } ],
+            [ asyncMethod, { x: 3, timeout: 75 } ],
+            [ asyncMethod, { x: 12, timeout: 100 } ],
+        ];
+
+        // @ts-ignore
+        // Calculate the sum prior to mutating the requests
+        const expectedSum = requests.reduce((total, req) => total + req[1].x, 0);
+
+        // Pop the last request for testing add()
+        const [lastRequestFn, lastRequestConfig] = requests.pop();
+
+        function onSend() {
+            // Assert
+            expect(sum).toEqual(expectedSum);
+            expect(this).toEqual(scope);
+            done();
+        }
+
+        // @ts-ignore
+        const multi = new MultiRequest(requests);
+
+        // Apply the last request using .add()
+        multi.add(lastRequestFn, lastRequestConfig, scope);
+
+        // Act
+        multi.send(onSend, scope);
+    });
+    it('supports listeners config', (done) => {
+        // Arrange
+        const scope = {};
+        let sum = 0;
+        function asyncMethod(config: any) {
+            sum += config.x;
+            setTimeout(config.success, config.timeout);
+        }
+
+        const requests = [
+            [ asyncMethod, { x: 13, timeout: 25 } ],
+            [ asyncMethod, { x: 5, timeout: 50 } ],
+            [ asyncMethod, { x: 71, timeout: 75 } ],
+        ];
+
+        // @ts-ignore
+        const expectedSum = requests.reduce((total, req) => total + req[1].x, 0);
+
+        function onSend() {
+            // Assert
+            expect(sum).toEqual(expectedSum);
+            expect(this).toEqual(scope);
+            done();
+        }
+
+        // Act
+        // @ts-ignore
+        new MultiRequest({
+            requests,
+            listeners: { done: { fn: onSend }, scope }
+        });
+    });
+});

--- a/src/labkey/MultiRequest.ts
+++ b/src/labkey/MultiRequest.ts
@@ -84,38 +84,11 @@ import { getOnFailure, getOnSuccess, isArray } from './Utils'
  * ```
 */
 export const MultiRequest = function(config: any) {
-    config = config || {};
-
-    let doneCallbacks: Array<any> = [];
-    let listeners;
-    let requests;
+    let doneCallbacks: any[] = [];
     let self = this;
     let sending = false;
-    let sendQ: Array<any> = [];
-    let waitQ: Array<any> = [];
-
-    if (isArray(config)) {
-        requests = config;
-    }
-    else {
-        requests = config.requests;
-        listeners = config.listeners;
-    }
-
-    if (requests) {
-        for (let i = 0; i < requests.length; i++) {
-            let request = requests[i];
-            this.add(request[0], request[1]);
-        }
-    }
-
-    if (listeners && listeners.done) {
-        applyCallback(listeners.done, listeners.scope);
-    }
-
-    if (waitQ.length && doneCallbacks.length > 0) {
-        this.send();
-    }
+    let sendQ: any[] = [];
+    let waitQ: any[] = [];
     
     function applyCallback(callback: any, scope: any) {
         if (typeof callback == 'function') {
@@ -124,7 +97,7 @@ export const MultiRequest = function(config: any) {
                 scope
             });
         }
-        else if (typeof callback.fn == 'function') {
+        else if (callback && typeof callback.fn == 'function') {
             doneCallbacks.push({
                 fn: callback.fn,
                 scope: callback.scope || scope
@@ -234,4 +207,33 @@ export const MultiRequest = function(config: any) {
 
         applyCallback(callback, scope);
     };
+
+    const cfg = config || {};
+    let listeners;
+    let requests;
+
+    if (isArray(cfg)) {
+        requests = cfg;
+    }
+    else {
+        requests = cfg.requests;
+        listeners = cfg.listeners;
+    }
+
+    if (requests) {
+        for (let i = 0; i < requests.length; i++) {
+            let request = requests[i];
+            this.add(request[0], request[1]);
+        }
+    }
+
+    if (listeners && listeners.done) {
+        applyCallback(listeners.done, listeners.scope);
+    }
+
+    if (waitQ.length && doneCallbacks.length > 0) {
+        this.send();
+    }
+
+    return this;
 };


### PR DESCRIPTION
#### Rationale
[Issue 41969](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41969) describes how `MultiRequest` is failing to process configured requests when passed into construction. This fixes that, fixes the return value to be `return this`, and adds a missing defensive check when processing callbacks.

#### Changes
* Move processing to end of method after instance methods have been added.
* Properly return `this` instance at end of construction.
* Add unit tests for `MultiRequest`.
