### PR TITLE
Item 8119: Asynchronous import for assay runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## XXX
+## 1.1.7 - 2021-01-11
 - Add optional fields to assay IImportRunOptions
 
 ## 1.1.6 - 2021-01-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## XXX
+- Add optional fields to assay IImportRunOptions
+
 ## 1.1.4 - 2020-12-15
 - Add optional useAsync parameter to IImportDataOptions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.7-fb-smAssayAsync.1",
+  "version": "1.1.7",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.4",
+  "version": "1.1.5-fb-smAssayAsync.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -36,6 +36,9 @@ export interface IImportRunOptions {
     reRunId?: number | string
     runFilePath?: string
     saveDataAsFile?: boolean
+    jobDescription?: string
+    jobNotificationProvider?: string
+    forceAsync?: boolean
     scope?: any
     success: Function
 }
@@ -89,6 +92,15 @@ export function importRun(options: IImportRunOptions): void {
     }
     if (options.saveDataAsFile) {
         formData.append('saveDataAsFile', options.saveDataAsFile ? "true" : "false");
+    }
+    if (options.jobDescription) {
+        formData.append('jobDescription', options.jobDescription);
+    }
+    if (options.jobNotificationProvider) {
+        formData.append('jobNotificationProvider', options.jobNotificationProvider);
+    }
+    if (options.forceAsync) {
+        formData.append('forceAsync', options.forceAsync ? "true" : "false");
     }
 
     if (options.properties) {


### PR DESCRIPTION
#### Rationale
A few additional parameters have been added to ImportRunApiForm to wire up async assay import for LKSM, so the client api needs to be modified accordingly. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1854
* https://github.com/LabKey/labkey-api-js/pull/84
* https://github.com/LabKey/labkey-ui-components/pull/427
* https://github.com/LabKey/sampleManagement/pull/448
* https://github.com/LabKey/biologics/pull/763

#### Changes
* Add optional fields to assay IImportRunOptions