### PR TITLE
Updates to @labkey/api package for version 1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## TBD - TBD
-- Item 8335: LABKEY.App change to use document.readyState and readystatechange to update isDOMContentLoaded prop. 
+## 1.1.8 - TBD
+- Issue 41508: LABKEY.App change to use document.readyState and readystatechange to update isDOMContentLoaded prop. 
 - Support specimen feature migration rename of `study-samples-api` to `specimen-api`.
 - Fix for Query `Response` to support response when `includeMetadata` flag is set to false.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## TBD - TBD
-- Item 8335: LABKEY.App change use document.readyState and readystatechange to update isDOMContentLoaded 
+- Item 8335: LABKEY.App change to use document.readyState and readystatechange to update isDOMContentLoaded prop 
 
 ## 1.1.7 - 2021-01-11
 - Add optional fields to assay IImportRunOptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Item 8335: LABKEY.App.loadApp: add forceInit param for case when the loadApp will be called after DOMContentLoaded 
+
 ## 1.1.7 - 2021-01-11
 - Add optional fields to assay IImportRunOptions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## TBD - TBD
-- Item 8335: LABKEY.App.loadApp: add forceInit param for case when the loadApp will be called after DOMContentLoaded 
+- Item 8335: LABKEY.App change use document.readyState and readystatechange to update isDOMContentLoaded 
 
 ## 1.1.7 - 2021-01-11
 - Add optional fields to assay IImportRunOptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.1.8 - TBD
+## 1.1.8 - 2021-02-19
 - Issue 41508: LABKEY.App change to use document.readyState and readystatechange to update isDOMContentLoaded prop. 
 - Support specimen feature migration rename of `study-samples-api` to `specimen-api`.
 - Fix for Query `Response` to support response when `includeMetadata` flag is set to false.
+- Add "title" property to the Project interface
 
 ## 1.1.7 - 2021-01-11
 - Add optional fields to assay IImportRunOptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## TBD - TBD
-- Item 8335: LABKEY.App change to use document.readyState and readystatechange to update isDOMContentLoaded prop 
+- Item 8335: LABKEY.App change to use document.readyState and readystatechange to update isDOMContentLoaded prop. 
+- Support specimen feature migration rename of `study-samples-api` to `specimen-api`.
+- Fix for Query `Response` to support response when `includeMetadata` flag is set to false.
 
 ## 1.1.7 - 2021-01-11
 - Add optional fields to assay IImportRunOptions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.7",
+  "version": "1.1.7-fb-lksProductNav.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.7",
+  "version": "1.1.7-fb-lksProductNav.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.7-fb-lksProductNav.3",
+  "version": "1.1.8",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.7-fb-lksProductNav.1",
+  "version": "1.1.7",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.7-fb-lksProductNav.2",
+  "version": "1.1.7-fb-lksProductNav.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.7-fb-lksProductNav.0",
+  "version": "1.1.7-fb-lksProductNav.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/App.ts
+++ b/src/labkey/App.ts
@@ -57,8 +57,9 @@ export function init(LABKEY: any) {
  * @param appName
  * @param appTarget
  * @param appContext
+ * @param forceInit used when you know the loadApp will be called after DOMContentLoaded
  */
-export function loadApp<CTX = any>(appName: string, appTarget: string, appContext: CTX): void {
+export function loadApp<CTX = any>(appName: string, appTarget: string, appContext: CTX, forceInit?: boolean): void {
     const appRegistry = getRegistry();
 
     if (appRegistry.registry.hasOwnProperty(appName)) {
@@ -67,7 +68,7 @@ export function loadApp<CTX = any>(appName: string, appTarget: string, appContex
             appRegistry.registry[appName].targets.push(appTarget);
         }
 
-        if (appRegistry.isDOMContentLoaded) {
+        if (appRegistry.isDOMContentLoaded || forceInit) {
             appRegistry.registry[appName].onInit(appTarget, appContext);
         } else {
             window.addEventListener(

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -61,6 +61,8 @@ export interface Project {
     path: string
     /** GUID of the root container, which is the parent for the project. */
     rootId: string
+    /** Title of the project. If none set, this will be the same as the project name. */
+    title: string
 }
 
 export enum ExperimentalFeatures {


### PR DESCRIPTION
#### Rationale
Several changes have been made to this package and it is time to bump the version number. See changes list below for specifics.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/447

#### Changes
* Issue 41508: LABKEY.App change to use document.readyState and readystatechange to update isDOMContentLoaded prop. 
* Support specimen feature migration rename of `study-samples-api` to `specimen-api`.
* Fix for Query `Response` to support response when `includeMetadata` flag is set to false.
* Add "title" property to the Project interface
