### PR TITLE
Correct controller name "specimens-api" -> "specimen-api"

### DIFF
--- a/src/labkey/Specimen.ts
+++ b/src/labkey/Specimen.ts
@@ -53,7 +53,7 @@ export function addSpecimensToRequest(options: AddSpecimensToRequestOptions): XM
     }
 
     return request({
-        url: buildURL('specimens-api', 'addSpecimensToRequest.api', options.containerPath),
+        url: buildURL('specimen-api', 'addSpecimensToRequest.api', options.containerPath),
         method: 'POST',
         jsonData: {
             preferredLocation: options.preferredLocation,
@@ -101,7 +101,7 @@ export function addVialsToRequest(options: AddVialsToRequestOptions): XMLHttpReq
     }
 
     return request({
-        url: buildURL('specimens-api', 'addVialsToRequest.api', options.containerPath),
+        url: buildURL('specimen-api', 'addVialsToRequest.api', options.containerPath),
         method: 'POST',
         jsonData: {
             idType: options.idType,
@@ -136,7 +136,7 @@ export function cancelRequest(options: CancelRequestOptions): XMLHttpRequest {
     }
 
     return request({
-        url: buildURL('specimens-api', 'cancelRequest.api', options.containerPath),
+        url: buildURL('specimen-api', 'cancelRequest.api', options.containerPath),
         method: 'POST',
         jsonData: {
             requestId: options.requestId
@@ -167,7 +167,7 @@ export function getOpenRequests(options: GetOpenRequestsOptions): XMLHttpRequest
     }
 
     return request({
-        url: buildURL('specimens-api', 'getOpenRequests.api', options.containerPath),
+        url: buildURL('specimen-api', 'getOpenRequests.api', options.containerPath),
         method: 'POST',
         jsonData: {
             allUsers: options.allUsers
@@ -201,7 +201,7 @@ export function getProvidingLocations(options: GetProvidingLocationsOptions): XM
     }
 
     return request({
-        url: buildURL('specimens-api', 'getProvidingLocations.api', options.containerPath),
+        url: buildURL('specimen-api', 'getProvidingLocations.api', options.containerPath),
         method: 'POST',
         jsonData: {
             specimenHashes: options.specimenHashArray
@@ -233,7 +233,7 @@ export function getRepositories(options: GetRepositoriesOptions): XMLHttpRequest
     }
 
     return request({
-        url: buildURL('specimens-api', 'getRepositories.api', options.containerPath),
+        url: buildURL('specimen-api', 'getRepositories.api', options.containerPath),
         method: 'POST',
         // No jsonData, still json request
         headers: {
@@ -268,7 +268,7 @@ export function getRequest(options: GetRequestOptions): XMLHttpRequest {
     }
 
     return request({
-        url: buildURL('specimens-api', 'getRequest.api', options.containerPath),
+        url: buildURL('specimen-api', 'getRequest.api', options.containerPath),
         method: 'POST',
         jsonData: {
             requestId: options.requestId
@@ -292,7 +292,7 @@ export interface GetSpecimenWebPartGroupsOptions extends RequestCallbackOptions 
  */
 export function getSpecimenWebPartGroups(options: GetSpecimenWebPartGroupsOptions): XMLHttpRequest {
     return request({
-        url: buildURL('specimens-api', 'getSpecimenWebPartGroups.api', options.containerPath),
+        url: buildURL('specimen-api', 'getSpecimenWebPartGroups.api', options.containerPath),
         method: 'POST',
         // No jsonData, still json request
         headers: {
@@ -323,7 +323,7 @@ export function getVialsByRowId(options: GetVialsByRowIdOptions): XMLHttpRequest
     }
 
     return request({
-        url: buildURL('specimens-api', 'getVialsByRowId.api', options.containerPath),
+        url: buildURL('specimen-api', 'getVialsByRowId.api', options.containerPath),
         method: 'POST',
         jsonData: {
             rowIds: options.vialRowIdArray
@@ -347,7 +347,7 @@ export interface GetVialTypeSummaryOptions extends RequestCallbackOptions {
  */
 export function getVialTypeSummary(options: GetVialTypeSummaryOptions): XMLHttpRequest {
     return request({
-        url: buildURL('specimens-api', 'getVialTypeSummary.api', options.containerPath),
+        url: buildURL('specimen-api', 'getVialTypeSummary.api', options.containerPath),
         method: 'POST',
         // No jsonData, still json request
         headers: {
@@ -388,7 +388,7 @@ export function removeVialsFromRequest(options: RemoveVialsFromRequestOptions): 
     }
 
     return request({
-        url: buildURL('specimens-api', 'removeVialsFromRequest', options.containerPath),
+        url: buildURL('specimen-api', 'removeVialsFromRequest', options.containerPath),
         method: 'POST',
         jsonData: {
             idType: options.idType,


### PR DESCRIPTION
#### Rationale
Previous PR flubbed the controller name; this corrects it.

No need to reversion/republish; we'll just take this fix whenever the next release happens. Server will continue to accept both controller names.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/87

#### Changes
* Correct controller name from `specimens-api` to `specimen-api`
