### PR TITLE
Item 8638: Aliquot grid and lineage update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## XX
-- Add materialRunType for Experiment.LineageOptions
+- Add runProtocolLsid for Experiment.LineageOptions
 
 ## 1.1.9 - 2021-02-23
 - Add enumeration for Security.PermissionRoles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## XX
+## 1.2.2 - 2021-04-05
 - Add runProtocolLsid for Experiment.LineageOptions
 
-## 1.2.1 - 2021-02-23
+## 1.2.1 - 2021-03-30
 - maxAllowedPHI renamed to maxAllowedPhi
 
-## 1.2.0 - 2021-02-23
+## 1.2.0 - 2021-03-30
 - Add maxAllowedPHI to UserWithPermissions
 
 ## 1.1.9 - 2021-02-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## XX
+- Add materialRunType for Experiment.LineageOptions
+
 ## 1.1.9 - 2021-02-23
 - Add enumeration for Security.PermissionRoles
 - Correct controller name "specimens-api" -> "specimen-api" 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.1.9",
+  "version": "1.1.10-fb-smAliquotGrid.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.2.2-fb-smAliquotGrid.1",
+  "version": "1.2.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -272,6 +272,11 @@ export interface LineageOptions extends ExperimentJSONConverterOptions, RequestC
     lsids?: string[]
     /** Include parents in the lineage response. Defaults to true. */
     parents?: boolean
+    /**
+     * Optional material lineage type to filter response -- either "AliquotationOnly" or "DerivationOnly".
+     * Defaults to include all.
+     */
+    materialRunType?: string
 }
 
 /**
@@ -304,6 +309,9 @@ export function lineage(options: LineageOptions): XMLHttpRequest {
     }
     if (options.cpasType) {
         params.cpasType = options.cpasType;
+    }
+    if (options.materialRunType) {
+        params.materialRunType = options.materialRunType;
     }
 
     return request({

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -273,10 +273,10 @@ export interface LineageOptions extends ExperimentJSONConverterOptions, RequestC
     /** Include parents in the lineage response. Defaults to true. */
     parents?: boolean
     /**
-     * Optional material lineage type to filter response -- either "AliquotationOnly" or "DerivationOnly".
+     * Optional Exp Run Protocol Lsid to filter response.
      * Defaults to include all.
      */
-    materialRunType?: string
+    runProtocolLsid?: string
 }
 
 /**
@@ -310,8 +310,8 @@ export function lineage(options: LineageOptions): XMLHttpRequest {
     if (options.cpasType) {
         params.cpasType = options.cpasType;
     }
-    if (options.materialRunType) {
-        params.materialRunType = options.materialRunType;
+    if (options.runProtocolLsid) {
+        params.runProtocolLsid = options.runProtocolLsid;
     }
 
     return request({


### PR DESCRIPTION
#### Rationale
Lineage query now supports filtering by material derivation type, so the js api needs to be adjusted accordingly. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2130
* https://github.com/LabKey/labkey-api-js/pull/92
* https://github.com/LabKey/labkey-ui-components/pull/485
* https://github.com/LabKey/inventory/pull/212
* https://github.com/LabKey/sampleManagement/pull/529

#### Changes
* Add materialRunType for Experiment.LineageOptions
