### PR TITLE
Item 8735: Allow for FormData to be passed via SendRequestOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Item 8735: Allow for FormData to be passed via SendRequestOptions
+
 ## 1.2.2 - 2021-04-05
 - Add runProtocolLsid for Experiment.LineageOptions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.3.0 - 2021-04-15
 - Item 8735: Allow for FormData to be passed via SendRequestOptions
 
 ## 1.2.2 - 2021-04-05

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.2.2-fb-filesForSampleAndSource.0",
+  "version": "1.2.2-fb-filesForSampleAndSource.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.2.2-fb-filesForSampleAndSource.1",
+  "version": "1.3.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.2.2",
+  "version": "1.2.2-fb-filesForSampleAndSource.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Rows.spec.ts
+++ b/src/labkey/query/Rows.spec.ts
@@ -72,6 +72,32 @@ describe('insertRows', () => {
             url: '/query/insertRows.api',
         }));
     });
+
+    it('should support form data', () => {
+        // Arrange
+        const requestSpy = jest.spyOn(Ajax, 'request').mockImplementation();
+        const schemaName = 'SSS';
+        const queryName = 'QQQ';
+        const rows = [{ rowId: 1 }, { rowId: 2 }];
+
+        const form = new FormData();
+        form.append('test1', 'test2');
+
+        // Act
+        (insertRows as any)({ schemaName, queryName, rows, form });
+
+        // Assert
+        expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+            method: 'POST',
+            form: expect.anything(),
+            jsonData: expect.objectContaining({
+                queryName,
+                rows,
+                schemaName,
+            }),
+            url: '/query/insertRows.api',
+        }));
+    });
 });
 
 describe('updateRows', () => {
@@ -91,6 +117,32 @@ describe('updateRows', () => {
         // Assert
         expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
             method: 'POST',
+            jsonData: expect.objectContaining({
+                queryName,
+                rows,
+                schemaName,
+            }),
+            url: '/query/updateRows.api',
+        }));
+    });
+
+    it('should support form data', () => {
+        // Arrange
+        const requestSpy = jest.spyOn(Ajax, 'request').mockImplementation();
+        const schemaName = 'SSS';
+        const queryName = 'QQQ';
+        const rows = [{ rowId: 1 }, { rowId: 2 }];
+
+        const form = new FormData();
+        form.append('test1', 'test2');
+
+        // Act
+        (updateRows as any)({ schemaName, queryName, rows, form });
+
+        // Assert
+        expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+            method: 'POST',
+            form: expect.anything(),
             jsonData: expect.objectContaining({
                 queryName,
                 rows,

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -32,6 +32,11 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
     /** **Experimental:** Optional extra context object passed into the transformation/validation script environment. */
     extraContext?: any
     /**
+     * FormData or Object consumable by FormData that can be used to POST key/value pairs of form information.
+     * For more information, see <a href="https://developer.mozilla.org/en-US/docs/Web/API/FormData">FormData documentation</a>.
+     */
+    form?: FormData | HTMLFormElement
+    /**
      * Name of a query table associated with the chosen schema.
      * See also: [How To Find schemaName, queryName & viewName](https://www.labkey.org/Documentation/wiki-page.view?name=findNames).
      */
@@ -297,6 +302,7 @@ function sendRequest(options: SendRequestOptions): XMLHttpRequest {
         method: 'POST',
         success: getCallbackWrapper(getOnSuccess(options), options.scope),
         failure: getCallbackWrapper(getOnFailure(options), options.scope, true),
+        form: options.form,
         jsonData: {
             schemaName: options.schemaName,
             queryName: options.queryName,


### PR DESCRIPTION
#### Rationale
As part of the story to enable file/attachment field types in the Sample Type and Source field editors for SM, this PR updates the api-js sendRequest function which is used by insertRows and updateRows so that it can take a FormData object as part of the POST body. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/94
* https://github.com/LabKey/labkey-ui-components/pull/498
* https://github.com/LabKey/platform/pull/2173
* https://github.com/LabKey/sampleManagement/pull/544
* https://github.com/LabKey/biologics/pull/853
* https://github.com/LabKey/inventory/pull/220

#### Changes
* Add "form" as property of QueryRequestOptions
* Update sendRequest to check for form property and move jsonData properties to form in that case
