### PR TITLE
Item 8958: Add permission classes for AddUserPermission and CanSeeAuditLogPermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.6.0 - 2021-06-10
 - Item 8958: Add permission classes for AddUserPermission and CanSeeAuditLogPermission
 
 ## 1.5.0 - 2021-05-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Item 8958: Add permission classes for AddUserPermission and CanSeeAuditLogPermission
+
 ## 1.5.0 - 2021-05-13
 - Item 8709: Add permission class for managing sample picklists
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.5.0-smPicklists.0",
+  "version": "1.5.0-fb-smPermissionsUpdates.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.5.0-fb-smPermissionsUpdates.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.5.0",
+  "version": "1.5.0-fb-smPermissionsUpdates.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.5.0-fb-smPermissionsUpdates.0",
+  "version": "1.6.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/constants.ts
+++ b/src/labkey/security/constants.ts
@@ -49,7 +49,9 @@ export enum PermissionTypes {
     Update = 'org.labkey.api.security.permissions.UpdatePermission',
 
     // Other
+    AddUser = 'org.labkey.api.security.permissions.AddUserPermission',
     ApplicationAdmin = 'org.labkey.api.security.permissions.ApplicationAdminPermission',
+    CanSeeAuditLog = 'org.labkey.api.audit.permissions.CanSeeAuditLogPermission',
     DesignAssay = 'org.labkey.api.assay.security.DesignAssayPermission',
     DesignDataClass = 'org.labkey.api.security.permissions.DesignDataClassPermission',
     DesignList = 'org.labkey.api.lists.permissions.DesignListPermission',
@@ -57,7 +59,6 @@ export enum PermissionTypes {
     ManagePicklists = 'org.labkey.api.lists.permissions.ManagePicklistsPermission',
     ReadSome = 'org.labkey.api.security.permissions.ReadSomePermission',
     UserManagement = 'org.labkey.api.security.permissions.UserManagementPermission',
-
 
     // Assay QC
     QCAnalyst = 'org.labkey.api.security.permissions.QCAnalystPermission',


### PR DESCRIPTION
#### Rationale
To support the SM app permissions page updates, this PR adds two more permissions classes to the PermissionTypes const to be used in the shared components library and app permission checks.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/553
* https://github.com/LabKey/platform/pull/2331
* https://github.com/LabKey/inventory/pull/253
* https://github.com/LabKey/biologics/pull/906
* https://github.com/LabKey/sampleManagement/pull/592

#### Changes
* Add permission classes for AddUserPermission and CanSeeAuditLogPermission to PermissionTypes
