### PR TITLE
Add `includeTriggers` option to `Query.getQueryDetails`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.3 - TBD
+- Add `includeTriggers` option to `Query.getQueryDetails`
+
 ## 1.6.2 - 2021-07-07
 - Update PermissionTypes.DesignSampleSet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.3 - TBD
+## 1.6.3 - 2021-07-12
 - Add `includeTriggers` option to `Query.getQueryDetails`
 
 ## 1.6.2 - 2021-07-07

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.2",
+  "version": "1.6.3-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.3-SNAPSHOT",
+  "version": "1.6.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.2",
+  "version": "1.6.3-SNAPSHOT",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/GetQueryDetails.ts
+++ b/src/labkey/query/GetQueryDetails.ts
@@ -113,6 +113,8 @@ export interface GetQueryDetailsOptions extends RequestCallbackOptions<QueryDeta
     /** A field key or Array of field keys to include in the metadata. */
     fields?: any
     fk?: any
+    /** Include trigger metadata in the response. */
+    includeTriggers?: boolean
     /** Initialize the view based on the default view iff the view doesn't yet exist. */
     initializeMissingView?: boolean
     /** The name of the query. */
@@ -159,6 +161,10 @@ export function getQueryDetails(options: GetQueryDetailsOptions): XMLHttpRequest
 
     if (options.initializeMissingView) {
         params.initializeMissingView = options.initializeMissingView;
+    }
+
+    if (options.includeTriggers !== undefined) {
+        params.includeTriggers = options.includeTriggers;
     }
 
     return request({


### PR DESCRIPTION
#### Rationale
Add `includeTriggers` option to `Query.getQueryDetails` to render trigger information in the schema browser

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2442

