### PR TITLE
add 'allowCrossRunFileInputs' option to LABKEY.Assay.importRun()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.4 - 2021-07-26
+- Add the `allowCrossRunFileInputs` flag to the `Assay.importRun()` API
+
 ## 1.6.3 - 2021-07-12
 - Add `includeTriggers` option to `Query.getQueryDetails`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -22,6 +22,7 @@ import { FormWindow } from './constants'
 declare let window: FormWindow;
 
 export interface IImportRunOptions {
+    allowCrossRunFileInputs?: boolean
     assayId?: number | string
     batchId?: number | string
     batchProperties?: any
@@ -90,7 +91,7 @@ export function importRun(options: IImportRunOptions): void {
     if (options.reRunId) {
         formData.append('reRunId', options.reRunId as string);
     }
-    if (options.saveDataAsFile) {
+    if (options.saveDataAsFile !== undefined) {
         formData.append('saveDataAsFile', options.saveDataAsFile ? "true" : "false");
     }
     if (options.jobDescription) {
@@ -99,8 +100,11 @@ export function importRun(options: IImportRunOptions): void {
     if (options.jobNotificationProvider) {
         formData.append('jobNotificationProvider', options.jobNotificationProvider);
     }
-    if (options.forceAsync) {
+    if (options.forceAsync !== undefined) {
         formData.append('forceAsync', options.forceAsync ? "true" : "false");
+    }
+    if (options.allowCrossRunFileInputs !== undefined) {
+        formData.append('allowCrossRunFileInputs', options.allowCrossRunFileInputs ? "true" : "false");
     }
 
     if (options.properties) {


### PR DESCRIPTION
#### Rationale
Add the `allowCrossRunFileInputs` flag to the `Assay.importRun()` API.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2491
* https://github.com/LabKey/platform/pull/2445
