### PR TITLE
QueryColumn: add "nameExpression" to interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.# - 2021-08-##
+- QueryColumn: add `nameExpression` to interface
+
 ## 1.6.4 - 2021-07-26
 - Add the `allowCrossRunFileInputs` flag to the `Assay.importRun()` API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.# - 2021-08-##
+## 1.6.5 - 2021-08-04
 - QueryColumn: add `nameExpression` to interface
 
 ## 1.6.4 - 2021-07-26

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.3-SNAPSHOT",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/types.ts
+++ b/src/labkey/query/types.ts
@@ -59,6 +59,7 @@ export interface QueryColumn {
     multiValue?: boolean
     mvEnabled: boolean
     name: string
+    nameExpression: string
     nullable: boolean
     phi: string
     rangeURI: string


### PR DESCRIPTION
#### Rationale
Update `QueryColumn` interface to include `nameExpression` property.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/959
* https://github.com/LabKey/platform/pull/2510
* https://github.com/LabKey/recipe/pull/56
* https://github.com/LabKey/labkey-api-js/pull/107
* https://github.com/LabKey/labkey-ui-components/pull/593

#### Changes
* QueryColumn: add `nameExpression` to interface
