### PR TITLE
v1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.6 - 2021-08-13
+- SaveRows: Update interface with schemaName/queryName (thanks @bbimber).
+
 ## 1.6.5 - 2021-08-04
 - QueryColumn: add `nameExpression` to interface
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",


### PR DESCRIPTION
#### Rationale
Publish `v1.6.6` of the package.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/108