### PR TITLE
43029: Support File/Attachment Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.7 - 2021-08-25
+- InsertRows/UpdateRows: Add capability to parse and transform row data into FormData when File data is present. 
+  This is accessible via a configuration flag `autoFormFileData`. 
+
 ## 1.6.6 - 2021-08-13
 - SaveRows: Update interface with schemaName/queryName (thanks @bbimber).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.5",
+  "version": "1.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.6-fb-fix-43029.1",
+  "version": "1.6.7",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.6-fb-fix-43029.0",
+  "version": "1.6.6-fb-fix-43029.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.6",
+  "version": "1.6.6-fb-fix-43029.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Rows.spec.ts
+++ b/src/labkey/query/Rows.spec.ts
@@ -15,6 +15,7 @@
  */
 import * as Ajax from '../Ajax'
 import {
+    bindFormData,
     deleteRows,
     insertRows,
     updateRows,
@@ -84,17 +85,33 @@ describe('insertRows', () => {
         form.append('test1', 'test2');
 
         // Act
-        (insertRows as any)({ schemaName, queryName, rows, form });
+        insertRows({ schemaName, queryName, rows, form });
 
         // Assert
         expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
             method: 'POST',
             form: expect.anything(),
-            jsonData: expect.objectContaining({
-                queryName,
-                rows,
-                schemaName,
-            }),
+            url: '/query/insertRows.api',
+        }));
+        expect(requestSpy).toHaveBeenCalledWith(expect.not.objectContaining({
+            jsonData: expect.anything(),
+        }));
+    });
+
+    it('should support file data', () => {
+        // Arrange
+        const requestSpy = jest.spyOn(Ajax, 'request').mockImplementation();
+        const schemaName = 'SSS';
+        const queryName = 'QQQ';
+        const rows = [{ rowId: 1 }, { rowId: 2 }, { rowId: 3, someFile: new File([], '') }];
+
+        // Act
+        insertRows({ autoFormFileData: true, schemaName, queryName, rows });
+
+        // Assert
+        expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+            method: 'POST',
+            form: expect.anything(),
             url: '/query/insertRows.api',
         }));
     });
@@ -137,18 +154,47 @@ describe('updateRows', () => {
         form.append('test1', 'test2');
 
         // Act
-        (updateRows as any)({ schemaName, queryName, rows, form });
+        updateRows({ schemaName, queryName, rows, form });
 
         // Assert
         expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
             method: 'POST',
             form: expect.anything(),
-            jsonData: expect.objectContaining({
-                queryName,
-                rows,
-                schemaName,
-            }),
             url: '/query/updateRows.api',
         }));
+        expect(requestSpy).toHaveBeenCalledWith(expect.not.objectContaining({
+            jsonData: expect.anything(),
+        }));
+    });
+});
+
+describe('bindFormData', () => {
+    const requestOptions = {
+        action: 'some.api',
+        autoFormFileData: true,
+        queryName: 'query',
+        schemaName: 'schema',
+    };
+    it('supports no form', () => {
+        expect(bindFormData({}, requestOptions)).toEqual(undefined);
+    });
+    it('supports user provided form', () => {
+        const expectedForm = new FormData();
+        expect(bindFormData({}, { ...requestOptions, form: expectedForm })).toEqual(expectedForm);
+    });
+    it('processes File data', () => {
+        // Arrange
+        const fileA = new File([], '');
+        const fileB = new File([], '');
+        const fileC = new File([], '');
+        const rows = [{ firstFile: fileA, rowId: 1 }, { rowId: 2, firstFile: fileC, secondFile: fileB }];
+
+        // Act
+        const form = bindFormData({ rows }, requestOptions, true);
+
+        expect(form).toBeDefined();
+        expect(form.get('firstFile::0')).toEqual(fileA);
+        expect(form.get('secondFile::1')).toEqual(fileB);
+        expect(form.get('firstFile::1')).toEqual(fileC);
     });
 });


### PR DESCRIPTION
#### Rationale
This addresses [Issue 43029](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43029) support for serializing `File` data in both `Query.insertRows()` and `Query.updateRows()` under a new flag called `autoFormFileData`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/110
* https://github.com/LabKey/labkey-ui-components/pull/610
* https://github.com/LabKey/biologics/pull/971
* https://github.com/LabKey/sampleManagement/pull/672
* https://github.com/LabKey/platform/pull/2563

#### Changes
* Introduce new capability to process `File` data into `FormData` and serialize it in the payload. This capability can be opted into by specifying `autoFormFileData` as `true`.
* Add unit tests for `File` processing.
