### PR TITLE
importRun: Add support for workflowTask param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.8 - 2021-10-21
+- importRun: Add support for workflowTask param.
+
 ## 1.6.7 - 2021-08-25
 - InsertRows/UpdateRows: Add capability to parse and transform row data into FormData when File data is present. 
   This is accessible via a configuration flag `autoFormFileData`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.8 - 2021-10-21
+## 1.6.8 - 2021-10-27
 - importRun: Add support for workflowTask param.
 
 ## 1.6.7 - 2021-08-25

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.7",
+  "version": "1.6.8-fb-lp-assay-task-client.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.8-fb-lp-assay-task-client.0",
+  "version": "1.6.8",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -42,6 +42,7 @@ export interface IImportRunOptions {
     forceAsync?: boolean
     scope?: any
     success: Function
+    workflowTask: number
 }
 
 export function importRun(options: IImportRunOptions): void {
@@ -105,6 +106,9 @@ export function importRun(options: IImportRunOptions): void {
     }
     if (options.allowCrossRunFileInputs !== undefined) {
         formData.append('allowCrossRunFileInputs', options.allowCrossRunFileInputs ? "true" : "false");
+    }
+    if (options.workflowTask !== undefined) {
+        formData.append('workflowTask', options.workflowTask.toString(10));
     }
 
     if (options.properties) {

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -42,7 +42,7 @@ export interface IImportRunOptions {
     forceAsync?: boolean
     scope?: any
     success: Function
-    workflowTask: number
+    workflowTask?: number
 }
 
 export function importRun(options: IImportRunOptions): void {


### PR DESCRIPTION
#### Rationale
I added workflowTask to the importRun API on the server, and we need support for it in our client.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2709

#### Changes
* importRun: Add support for workflowTask param