### PR TITLE
Issue 44277: SM: creating aliquots using Experiment.saveRuns api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## XXX - XXX
+- Add SAMPLE_ALIQUOT_PROTOCOL const to Experiment
+
 ## 1.6.8 - 2021-10-27
 - importRun: Add support for workflowTask param.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## XXX - XXX
+## 1.6.9 - 2021-11-10
 - Add SAMPLE_ALIQUOT_PROTOCOL const to Experiment
 
 ## 1.6.8 - 2021-10-27

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.9-fb-issue44277",
+  "version": "1.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.7",
+  "version": "1.6.9-fb-issue44277",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.9-fb-issue44277",
+  "version": "1.6.9",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.8",
+  "version": "1.6.9-fb-issue44277",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -22,6 +22,7 @@ import { Run, RunGroup } from './Exp'
 
 /** The name of the protocol used by Experiment. This can be used for "protocolName". */
 export const SAMPLE_DERIVATION_PROTOCOL = 'Sample Derivation Protocol';
+export const SAMPLE_ALIQUOT_PROTOCOL = 'Sample Aliquot Protocol';
 
 /**
  * Several Experiment API endpoints expose optional settings for the ExperimentJSONConverter.


### PR DESCRIPTION
#### Rationale
Add SAMPLE_ALIQUOT_PROTOCOL to LabKey.Experiment to be consistent with SAMPLE_DERIVATION_PROTOCOL

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/115
* https://github.com/LabKey/labkey-ui-components/pull/670
* https://github.com/LabKey/platform/pull/2765

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
