### PR TITLE
CurrentAndSubfoldersPlusShared Container Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.#.# - 2021-1#-##
+- Add `currentAndSubfoldersPlusShared` container filter type to enumeration.
+- Allow for `effectivePermissions` to be declared on a `Container`. Only relevant when supplied by certain endpoints, so it is marked as optional.
+- Export `Security` interfaces so they are published to public typings.
+
 ## 1.6.9 - 2021-11-10
 - Add SAMPLE_ALIQUOT_PROTOCOL const to Experiment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.#.# - 2021-1#-##
+## 1.6.10 - 2021-11-30
 - Add `currentAndSubfoldersPlusShared` container filter type to enumeration.
 - Allow for `effectivePermissions` to be declared on a `Container`. Only relevant when supplied by certain endpoints, so it is marked as optional.
 - Export `Security` interfaces so they are published to public typings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.9-fb-subfolder-perms.0",
+  "version": "1.6.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.9",
+  "version": "1.6.9-fb-subfolder-perms.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.9",
+  "version": "1.6.9-fb-subfolder-perms.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.6.9-fb-subfolder-perms.0",
+  "version": "1.6.10",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Security.ts
+++ b/src/labkey/Security.ts
@@ -25,14 +25,21 @@ import {
 } from './security/constants'
 import {
     createContainer,
+    CreateContainerOptions,
     deleteContainer,
+    DeleteContainerOptions,
     getContainers,
+    GetContainersOptions,
     getFolderTypes,
+    GetFolderTypesOptions,
     getHomeContainer,
     getModules,
+    GetModulesOptions,
     getReadableContainers,
+    GetReadableContainersOptions,
     getSharedContainer,
-    moveContainer
+    moveContainer,
+    MoveContainerOptions,
 } from './security/Container'
 import {
     getGroupPermissions,
@@ -74,6 +81,15 @@ export {
     permissions,
     roles,
     systemGroups,
+
+    /* interfaces */
+    CreateContainerOptions,
+    DeleteContainerOptions,
+    GetContainersOptions,
+    GetFolderTypesOptions,
+    GetModulesOptions,
+    GetReadableContainersOptions,
+    MoveContainerOptions,
 
     /* methods */
     addGroupMembers,

--- a/src/labkey/Security.ts
+++ b/src/labkey/Security.ts
@@ -24,6 +24,7 @@ import {
     systemGroups
 } from './security/constants'
 import {
+    ContainerHierarchy,
     createContainer,
     CreateContainerOptions,
     deleteContainer,
@@ -83,6 +84,7 @@ export {
     systemGroups,
 
     /* interfaces */
+    ContainerHierarchy,
     CreateContainerOptions,
     DeleteContainerOptions,
     GetContainersOptions,

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -16,8 +16,6 @@
 export interface Container {
     /** Names of active modules in the container. */
     activeModules: string[];
-    /** Permissions the requesting user has in the container. */
-    effectivePermissions: string[];
     /** The name of the container's folder type. */
     folderType: string;
     /** Date format settings for this container. */

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -16,6 +16,11 @@
 export interface Container {
     /** Names of active modules in the container. */
     activeModules: string[];
+    /**
+     * Permissions the requesting user has in the container.
+     * Only available when explicitly requested via Security.getContainers().
+     */
+    effectivePermissions?: string[];
     /** The name of the container's folder type. */
     folderType: string;
     /** Date format settings for this container. */

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -16,6 +16,8 @@
 export interface Container {
     /** Names of active modules in the container. */
     activeModules: string[];
+    /** Permissions the requesting user has in the container. */
+    effectivePermissions: string[];
     /** The name of the container's folder type. */
     folderType: string;
     /** Date format settings for this container. */

--- a/src/labkey/query/Utils.spec.ts
+++ b/src/labkey/query/Utils.spec.ts
@@ -24,12 +24,13 @@ describe('ContainerFilter', () => {
         expect(ContainerFilter.currentAndFirstChildren).toEqual('CurrentAndFirstChildren');
         expect(ContainerFilter.currentAndParents).toEqual('CurrentAndParents');
         expect(ContainerFilter.currentAndSubfolders).toEqual('CurrentAndSubfolders');
+        expect(ContainerFilter.currentAndSubfoldersPlusShared).toEqual('CurrentAndSubfoldersPlusShared');
         expect(ContainerFilter.currentPlusProject).toEqual('CurrentPlusProject');
         expect(ContainerFilter.currentPlusProjectAndShared).toEqual('CurrentPlusProjectAndShared');
 
         // All "values" of the ContainerFilter enum should be covered here -- if it has changed
         // this test will fail and the test should be updated accordingly.
-        expect(Object.keys(ContainerFilter).length).toEqual(7);
+        expect(Object.keys(ContainerFilter).length).toEqual(8);
     });
     it('should be equivalent to "containerFilter"', () => {
         // Backwards compatibility support

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -52,7 +52,7 @@ export enum ContainerFilter {
     /** Include the current folder and all subfolders. */
     currentAndSubfolders = 'CurrentAndSubfolders',
 
-    /** Include the current folder, all subfolders of the current folder, and any shared folder. */
+    /** Include the current folder, all subfolders of the current folder, and the Shared folder. */
     currentAndSubfoldersPlusShared = 'CurrentAndSubfoldersPlusShared',
 
     /** Include the current folder and the project that contains it. */

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -52,6 +52,9 @@ export enum ContainerFilter {
     /** Include the current folder and all subfolders. */
     currentAndSubfolders = 'CurrentAndSubfolders',
 
+    /** Include the current folder, all subfolders of the current folder, and any shared folder. */
+    currentAndSubfoldersPlusShared = 'CurrentAndSubfoldersPlusShared',
+
     /** Include the current folder and the project that contains it. */
     currentPlusProject = 'CurrentPlusProject',
 


### PR DESCRIPTION
#### Rationale
Adds support for `CurrentAndSubfoldersPlusShared` container filter type. Additionally, update the typings for `Security` module to be more easily utilized by external users.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2802
* https://github.com/LabKey/labkey-api-js/pull/116
* https://github.com/LabKey/labkey-ui-components/pull/679
* https://github.com/LabKey/sampleManagement/pull/761
* https://github.com/LabKey/biologics/pull/1070

#### Changes
* Add `currentAndSubfoldersPlusShared` container filter type to enumeration.
* Allow for `effectivePermissions` to be declared on a `Container`. Only relevant when supplied by certain endpoints, so it is marked as optional.
* Export `Security` interfaces so they are published to public typings.
