### PR TITLE
Item 9731: Naming pattern improvement - updates for genId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## XXX - XXX
+- Add setGenId, getGenId methods to Experiment
+
 ## 1.7.1 - 2021-12-23
 - Add validateNameExpressions, getDomainNamePreviews methods to Domain
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## XXX - XXX
+## 1.7.2 - 2022-01-04
 - Add setGenId, getGenId methods to Experiment
 
 ## 1.7.1 - 2021-12-23

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.2-fb-setGenId.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.1",
+  "version": "1.7.2-fb-setGenId.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.1",
+  "version": "1.7.2-fb-setGenId.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.2-fb-setGenId.1",
+  "version": "1.7.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -598,3 +598,44 @@ export function saveRuns(options: SaveRunsOptions): XMLHttpRequest {
         failure: getCallbackWrapper(getOnFailure(options), options.scope, true)
     });
 }
+
+export interface GenIdActionsOptions extends RequestCallbackOptions {
+    containerPath?: string
+    rowId: number
+    kindName: 'SampleSet' | "DataClass"
+    genId?: number
+
+}
+/**
+ * Set the current genId sequence for the data type (sampleset or dataclass)
+ */
+export function setGenId(config: GenIdActionsOptions): XMLHttpRequest {
+
+    return request({
+        url: buildURL('experiment', 'setGenId.api', config.containerPath),
+        method: 'POST',
+        success: getCallbackWrapper(getOnSuccess(config), config.scope),
+        failure: getCallbackWrapper(getOnFailure(config), config.scope, true),
+        jsonData: {
+            rowId: config.rowId,
+            kindName: config.kindName,
+            genId: config.genId
+        }
+    });
+}
+
+/**
+ * Get the current genId for the data type (sampleset or dataclass)
+ */
+export function getGenId(config: GenIdActionsOptions): XMLHttpRequest {
+
+    return request({
+        url: buildURL('experiment', 'getGenId.api', config.containerPath),
+        success: getCallbackWrapper(getOnSuccess(config), config.scope),
+        failure: getCallbackWrapper(getOnFailure(config), config.scope, true),
+        params: {
+            rowId: config.rowId,
+            kindName: config.kindName
+        }
+    });
+}

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -607,7 +607,7 @@ export interface GenIdActionsOptions extends RequestCallbackOptions {
 
 }
 /**
- * Set the current genId sequence for the data type (sampleset or dataclass)
+ * Set the current genId sequence value for the data type (sampleset or dataclass)
  */
 export function setGenId(config: GenIdActionsOptions): XMLHttpRequest {
 


### PR DESCRIPTION
#### Rationale
Add support to reset and update genIds

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/119
* https://github.com/LabKey/labkey-ui-components/pull/698
* https://github.com/LabKey/platform/pull/2912
* https://github.com/LabKey/sampleManagement/pull/791
* https://github.com/LabKey/biologics/pull/1111

#### Changes
* Add setGenId, getGenId methods to Experiment
