### PR TITLE
Update saveQueryViews interface to support additional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - 2022-TBD
+## 1.7.3 - 2022-01-21
 - Update interface of `Query.saveQueryViews`, fixing types and adding supported options
 
 ## 1.7.2 - 2022-01-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - 2022-TBD
+- Update interface of `Query.saveQueryViews`, fixing types and adding supported options
+
 ## 1.7.2 - 2022-01-04
 - Add setGenId, getGenId methods to Experiment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.3-sampleFinderTabbedGrids.0",
+  "version": "1.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.7.3-sampleFinderTabbedGrids.0",
+      "version": "1.7.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.2",
+  "version": "1.7.3-sampleFinderTabbedGrids.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.7.2",
+      "version": "1.7.3-sampleFinderTabbedGrids.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.3-sampleFinderTabbedGrids.0",
+  "version": "1.7.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.7.2",
+  "version": "1.7.3-sampleFinderTabbedGrids.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -416,7 +416,10 @@ export interface SaveQueryViewsOptions extends RequestCallbackOptions {
     metadata?: any
     queryName?: string
     schemaName?: string
-    views?: string
+    views?: any
+    shared?: boolean
+    session?: boolean
+    hidden?: boolean
 }
 
 /**
@@ -434,6 +437,15 @@ export function saveQueryViews(options: SaveQueryViewsOptions): XMLHttpRequest {
     }
     if (options.views) {
         jsonData.views = options.views;
+    }
+    if (options.shared) {
+        jsonData.shared = true;
+    }
+    if (options.session) {
+        jsonData.session = true;
+    }
+    if (options.hidden) {
+        jsonData.hidden = true;
     }
 
     return request({


### PR DESCRIPTION
#### Rationale
The server-side action for `SaveQueryViews` has a few options that are not yet exposed through the JS API and one option that was incorrectly typed. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/709

#### Changes
* Update interface of `Query.saveQueryViews`, fixing types and adding supported options
