### PR TITLE
Item 10056: Sample Finder v1 - Wire up new lineage filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.XX.0 - 2022-02-XX
+## 1.10.0 - 2022-02-28
 - Add getLabKeySqlOperator to IFilterType
 
 ## 1.9.0 - 2022-02-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.XX.0 - 2022-02-XX
+- Add getLabKeySqlOperator to IFilterType
+
 ## 1.9.0 - 2022-02-16
 - Add new reader permission classes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.9.0",
+  "version": "1.10.0-fb-sampleFinderLineageSql.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.9.0",
+      "version": "1.10.0-fb-sampleFinderLineageSql.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-sampleFinderLineageSql.1",
+  "version": "1.10.0-fb-sampleFinderLineageSql.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.10.0-fb-sampleFinderLineageSql.1",
+      "version": "1.10.0-fb-sampleFinderLineageSql.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-sampleFinderLineageSql.2",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.10.0-fb-sampleFinderLineageSql.2",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-sampleFinderLineageSql.1",
+  "version": "1.10.0-fb-sampleFinderLineageSql.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.9.0",
+  "version": "1.10.0-fb-sampleFinderLineageSql.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-sampleFinderLineageSql.2",
+  "version": "1.10.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/filter/Types.ts
+++ b/src/labkey/filter/Types.ts
@@ -47,22 +47,22 @@ export interface IFilterType {
 }
 
 /** Finds rows where the column value matches the given filter value. Case-sensitivity depends upon how your underlying relational database was configured.*/
-const EQUAL = registerFilterType('Equals', '=', 'eq', true, '=');
+const EQUAL = registerFilterType('Equals', '=', 'eq', true, undefined, undefined, undefined, undefined, false, '=');
 /** Finds rows where the column value is greater than the filter value.*/
-const GREATER_THAN = registerFilterType('Is Greater Than', '>', 'gt', true, '>');
+const GREATER_THAN = registerFilterType('Is Greater Than', '>', 'gt', true, undefined, undefined, undefined, undefined, false, '>');
 /** Finds rows where the column value is greater than or equal to the filter value.*/
-const GREATER_THAN_OR_EQUAL = registerFilterType('Is Greater Than or Equal To', '>=', 'gte', true, '>=');
+const GREATER_THAN_OR_EQUAL = registerFilterType('Is Greater Than or Equal To', '>=', 'gte', true, undefined, undefined, undefined, undefined, false, '>=');
 /** Finds rows where the column value equals one of the supplied filter values. The values should be supplied as a semi-colon-delimited list (example usage: a;b;c).*/
-const IN = registerFilterType('Equals One Of', null, 'in', true, null, ';', 'Equals One Of (example usage: a;b;c)');
+const IN = registerFilterType('Equals One Of', null, 'in', true, ';', 'Equals One Of (example usage: a;b;c)');
 /** Finds rows where the column value is less than the filter value.*/
-const LESS_THAN = registerFilterType('Is Less Than', '<', 'lt', true, '<');
+const LESS_THAN = registerFilterType('Is Less Than', '<', 'lt', true, undefined, undefined, undefined, undefined, false, '<');
 /** Finds rows where the column value is less than or equal to the filter value.*/
-const LESS_THAN_OR_EQUAL = registerFilterType('Is Less Than or Equal To', '=<', 'lte', true, '<=');
+const LESS_THAN_OR_EQUAL = registerFilterType('Is Less Than or Equal To', '=<', 'lte', true, undefined, undefined, undefined, undefined, false, '<=');
 /** Finds rows where the column value does not equal the filter value.*/
-const NOT_EQUAL = registerFilterType('Does Not Equal', '<>', 'neq', true, '<>');
+const NOT_EQUAL = registerFilterType('Does Not Equal', '<>', 'neq', true, undefined, undefined, undefined, undefined, false, '<>');
 /** Finds rows where the column value is not in any of the supplied filter values. The values should be supplied as a semi-colon-delimited list (example usage: a;b;c).*/
-const NOT_IN = registerFilterType('Does Not Equal Any Of', null, 'notin', true, null, ';', 'Does Not Equal Any Of (example usage: a;b;c)');
-const NEQ_OR_NULL = registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'neqornull', true, null);
+const NOT_IN = registerFilterType('Does Not Equal Any Of', null, 'notin', true, ';', 'Does Not Equal Any Of (example usage: a;b;c)');
+const NEQ_OR_NULL = registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'neqornull', true);
 
 // Mutable due to "_define"
 export let Types: Record<string, IFilterType> = {
@@ -72,30 +72,30 @@ export let Types: Record<string, IFilterType> = {
     //
 
     EQUAL,
-    DATE_EQUAL: registerFilterType(EQUAL.getDisplayText(), EQUAL.getDisplaySymbol(), 'dateeq', true, EQUAL.getLabKeySqlOperator()),
+    DATE_EQUAL: registerFilterType(EQUAL.getDisplayText(), EQUAL.getDisplaySymbol(), 'dateeq', true, undefined, undefined, undefined, undefined, false, EQUAL.getLabKeySqlOperator()),
 
     NOT_EQUAL,
     NEQ: NOT_EQUAL,
-    DATE_NOT_EQUAL: registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'dateneq', true, NOT_EQUAL.getLabKeySqlOperator()),
+    DATE_NOT_EQUAL: registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'dateneq', true, undefined, undefined, undefined, undefined, false, NOT_EQUAL.getLabKeySqlOperator()),
 
     NEQ_OR_NULL,
     NOT_EQUAL_OR_MISSING: NEQ_OR_NULL,
 
     GREATER_THAN,
     GT: GREATER_THAN,
-    DATE_GREATER_THAN: registerFilterType(GREATER_THAN.getDisplayText(), GREATER_THAN.getDisplaySymbol(), 'dategt', true, GREATER_THAN.getLabKeySqlOperator()),
+    DATE_GREATER_THAN: registerFilterType(GREATER_THAN.getDisplayText(), GREATER_THAN.getDisplaySymbol(), 'dategt', true, undefined, undefined, undefined, undefined, false, GREATER_THAN.getLabKeySqlOperator()),
 
     LESS_THAN,
     LT: LESS_THAN,
-    DATE_LESS_THAN: registerFilterType(LESS_THAN.getDisplayText(), LESS_THAN.getDisplaySymbol(), 'datelt', true, LESS_THAN.getLabKeySqlOperator()),
+    DATE_LESS_THAN: registerFilterType(LESS_THAN.getDisplayText(), LESS_THAN.getDisplaySymbol(), 'datelt', true, undefined, undefined, undefined, undefined, false, LESS_THAN.getLabKeySqlOperator()),
 
     GREATER_THAN_OR_EQUAL,
     GTE : GREATER_THAN_OR_EQUAL,
-    DATE_GREATER_THAN_OR_EQUAL: registerFilterType(GREATER_THAN_OR_EQUAL.getDisplayText(), GREATER_THAN_OR_EQUAL.getDisplaySymbol(), 'dategte', true, GREATER_THAN_OR_EQUAL.getLabKeySqlOperator()),
+    DATE_GREATER_THAN_OR_EQUAL: registerFilterType(GREATER_THAN_OR_EQUAL.getDisplayText(), GREATER_THAN_OR_EQUAL.getDisplaySymbol(), 'dategte', true, undefined, undefined, undefined, undefined, false, GREATER_THAN_OR_EQUAL.getLabKeySqlOperator()),
 
     LESS_THAN_OR_EQUAL,
     LTE: LESS_THAN_OR_EQUAL,
-    DATE_LESS_THAN_OR_EQUAL: registerFilterType(LESS_THAN_OR_EQUAL.getDisplayText(), LESS_THAN_OR_EQUAL.getDisplaySymbol(), 'datelte', true, LESS_THAN_OR_EQUAL.getLabKeySqlOperator()),
+    DATE_LESS_THAN_OR_EQUAL: registerFilterType(LESS_THAN_OR_EQUAL.getDisplayText(), LESS_THAN_OR_EQUAL.getDisplaySymbol(), 'datelte', true, undefined, undefined, undefined, undefined, false, LESS_THAN_OR_EQUAL.getLabKeySqlOperator()),
 
     STARTS_WITH: registerFilterType('Starts With', null, 'startswith', true),
     DOES_NOT_START_WITH: registerFilterType('Does Not Start With', null, 'doesnotstartwith', true),
@@ -103,8 +103,8 @@ export let Types: Record<string, IFilterType> = {
     CONTAINS: registerFilterType('Contains', null, 'contains', true),
     DOES_NOT_CONTAIN: registerFilterType('Does Not Contain', null, 'doesnotcontain', true),
 
-    CONTAINS_ONE_OF: registerFilterType('Contains One Of', null, 'containsoneof', true, null, ';', 'Contains One Of (example usage: a;b;c)'),
-    CONTAINS_NONE_OF: registerFilterType('Does Not Contain Any Of', null, 'containsnoneof', true, null, ';', 'Does Not Contain Any Of (example usage: a;b;c)'),
+    CONTAINS_ONE_OF: registerFilterType('Contains One Of', null, 'containsoneof', true, ';', 'Contains One Of (example usage: a;b;c)'),
+    CONTAINS_NONE_OF: registerFilterType('Does Not Contain Any Of', null, 'containsnoneof', true, ';', 'Does Not Contain Any Of (example usage: a;b;c)'),
 
     // NOTE: for some reason IN is aliased as EQUALS_ONE_OF. Not sure if this is for legacy purposes or it was
     // determined EQUALS_ONE_OF was a better phrase to follow this pattern I did the same for IN_OR_MISSING
@@ -114,14 +114,14 @@ export let Types: Record<string, IFilterType> = {
     NOT_IN,
     EQUALS_NONE_OF: NOT_IN,
 
-    BETWEEN: registerFilterType('Between', null, 'between', true, null,  ',', 'Between, Inclusive (example usage: -4,4)', 2, 2),
-    NOT_BETWEEN: registerFilterType('Not Between', null, 'notbetween', true, null,  ',', 'Not Between, Exclusive (example usage: -4,4)', 2, 2),
+    BETWEEN: registerFilterType('Between', null, 'between', true, ',', 'Between, Inclusive (example usage: -4,4)', 2, 2),
+    NOT_BETWEEN: registerFilterType('Not Between', null, 'notbetween', true, ',', 'Not Between, Exclusive (example usage: -4,4)', 2, 2),
 
-    MEMBER_OF: registerFilterType('Member Of', null, 'memberof', true, null,  undefined, 'Member Of'),
+    MEMBER_OF: registerFilterType('Member Of', null, 'memberof', true, undefined, 'Member Of'),
 
-    EXP_CHILD_OF: registerFilterType('Is Child Of', null, 'exp:childof', true, null,  undefined, ' is child of'),
-    EXP_PARENT_OF: registerFilterType('Is Parent Of', null, 'exp:parentof', true, null, undefined, ' is parent of'),
-    EXP_LINEAGE_OF: registerFilterType('In The Lineage Of', null, 'exp:lineageof', true, null, ',', ' in the lineage of'),
+    EXP_CHILD_OF: registerFilterType('Is Child Of', null, 'exp:childof', true, undefined, ' is child of'),
+    EXP_PARENT_OF: registerFilterType('Is Parent Of', null, 'exp:parentof', true, undefined, ' is parent of'),
+    EXP_LINEAGE_OF: registerFilterType('In The Lineage Of', null, 'exp:lineageof', true, ',', ' in the lineage of'),
 
     //
     // These are the 'no data value' operators
@@ -131,10 +131,10 @@ export let Types: Record<string, IFilterType> = {
     // The result is a filter that is encoded as "<dataRegionName>.<columnName>~=".
     HAS_ANY_VALUE: registerFilterType('Has Any Value', null, ''),
 
-    ISBLANK: registerFilterType('Is Blank', null, 'isblank', false, 'IS NULL'),
-    MISSING: registerFilterType('Is Blank', null, 'isblank', false, 'IS NULL'),
-    NONBLANK: registerFilterType('Is Not Blank', null, 'isnonblank', false, 'IS NOT NULL'),
-    NOT_MISSING: registerFilterType('Is Not Blank', null, 'isnonblank', false, 'IS NOT NULL'),
+    ISBLANK: registerFilterType('Is Blank', null, 'isblank', false, undefined, undefined, undefined, undefined, false, 'IS NULL'),
+    MISSING: registerFilterType('Is Blank', null, 'isblank', false, undefined, undefined, undefined, undefined, false, 'IS NULL'),
+    NONBLANK: registerFilterType('Is Not Blank', null, 'isnonblank', false, undefined, undefined, undefined, undefined, false, 'IS NOT NULL'),
+    NOT_MISSING: registerFilterType('Is Not Blank', null, 'isnonblank', false, undefined, undefined, undefined, undefined, false, 'IS NOT NULL'),
 
     HAS_MISSING_VALUE: registerFilterType('Has a missing value indicator', null, 'hasmvvalue'),
     DOES_NOT_HAVE_MISSING_VALUE: registerFilterType('Does not have a missing value indicator', null, 'nomvvalue'),
@@ -142,7 +142,7 @@ export let Types: Record<string, IFilterType> = {
     //
     // Table/Query-wise operators
     //
-    Q: registerFilterType('Search', null, 'q', true, null, undefined, 'Search across all columns', undefined, undefined, true),
+    Q: registerFilterType('Search', null, 'q', true, undefined, 'Search across all columns', undefined, undefined, true),
     //
     // Ontology operators
     //
@@ -230,11 +230,12 @@ export function getFilterTypesForType(jsonType: JsonType, mvEnabled?: boolean): 
  * @param minOccurs The minimum number of times the filter can be applied
  * @param maxOccurs The maximum number of times the filter can be applied
  * @param tableWise true if the filter applies to all columns on the table
+ * @param labkeySqlOperator The simple operator to use for generating labkey sql
  */
 export function registerFilterType(
     displayText: string, displaySymbol?: string, urlSuffix?: string,
-    dataValueRequired?: boolean, labkeySqlOperator?: string, multiValueSeparator?: string, longDisplayText?: string,
-    minOccurs?: number, maxOccurs?: number, tableWise?: boolean
+    dataValueRequired?: boolean, multiValueSeparator?: string, longDisplayText?: string,
+    minOccurs?: number, maxOccurs?: number, tableWise?: boolean, labkeySqlOperator?: string
 ): IFilterType {
     const isDataValueRequired = () => dataValueRequired === true;
     const isMultiValued = () => multiValueSeparator != null;

--- a/src/labkey/filter/Types.ts
+++ b/src/labkey/filter/Types.ts
@@ -42,7 +42,9 @@ export interface IFilterType {
      */
     getURLParameterValue: (value: FilterValue) => FilterValue
     validate: (value: FilterValue, jsonType: string, columnName: string) => any
-
+    /**
+     * Get the LabKey SQL operator for simple filter types (=, >=, <>)
+     */
     getLabKeySqlOperator: () => string
 }
 

--- a/src/labkey/filter/Types.ts
+++ b/src/labkey/filter/Types.ts
@@ -42,25 +42,27 @@ export interface IFilterType {
      */
     getURLParameterValue: (value: FilterValue) => FilterValue
     validate: (value: FilterValue, jsonType: string, columnName: string) => any
+
+    getLabKeySqlOperator: () => string
 }
 
 /** Finds rows where the column value matches the given filter value. Case-sensitivity depends upon how your underlying relational database was configured.*/
-const EQUAL = registerFilterType('Equals', '=', 'eq', true);
+const EQUAL = registerFilterType('Equals', '=', 'eq', true, '=');
 /** Finds rows where the column value is greater than the filter value.*/
-const GREATER_THAN = registerFilterType('Is Greater Than', '>', 'gt', true);
+const GREATER_THAN = registerFilterType('Is Greater Than', '>', 'gt', true, '>');
 /** Finds rows where the column value is greater than or equal to the filter value.*/
-const GREATER_THAN_OR_EQUAL = registerFilterType('Is Greater Than or Equal To', '>=', 'gte', true);
+const GREATER_THAN_OR_EQUAL = registerFilterType('Is Greater Than or Equal To', '>=', 'gte', true, '>=');
 /** Finds rows where the column value equals one of the supplied filter values. The values should be supplied as a semi-colon-delimited list (example usage: a;b;c).*/
-const IN = registerFilterType('Equals One Of', null, 'in', true, ';', 'Equals One Of (example usage: a;b;c)');
+const IN = registerFilterType('Equals One Of', null, 'in', true, null, ';', 'Equals One Of (example usage: a;b;c)');
 /** Finds rows where the column value is less than the filter value.*/
-const LESS_THAN = registerFilterType('Is Less Than', '<', 'lt', true);
+const LESS_THAN = registerFilterType('Is Less Than', '<', 'lt', true, '<');
 /** Finds rows where the column value is less than or equal to the filter value.*/
-const LESS_THAN_OR_EQUAL = registerFilterType('Is Less Than or Equal To', '=<', 'lte', true);
+const LESS_THAN_OR_EQUAL = registerFilterType('Is Less Than or Equal To', '=<', 'lte', true, '<=');
 /** Finds rows where the column value does not equal the filter value.*/
-const NOT_EQUAL = registerFilterType('Does Not Equal', '<>', 'neq', true);
+const NOT_EQUAL = registerFilterType('Does Not Equal', '<>', 'neq', true, '<>');
 /** Finds rows where the column value is not in any of the supplied filter values. The values should be supplied as a semi-colon-delimited list (example usage: a;b;c).*/
-const NOT_IN = registerFilterType('Does Not Equal Any Of', null, 'notin', true, ';', 'Does Not Equal Any Of (example usage: a;b;c)');
-const NEQ_OR_NULL = registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'neqornull', true);
+const NOT_IN = registerFilterType('Does Not Equal Any Of', null, 'notin', true, null, ';', 'Does Not Equal Any Of (example usage: a;b;c)');
+const NEQ_OR_NULL = registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'neqornull', true, null);
 
 // Mutable due to "_define"
 export let Types: Record<string, IFilterType> = {
@@ -70,30 +72,30 @@ export let Types: Record<string, IFilterType> = {
     //
 
     EQUAL,
-    DATE_EQUAL: registerFilterType(EQUAL.getDisplayText(), EQUAL.getDisplaySymbol(), 'dateeq', true),
+    DATE_EQUAL: registerFilterType(EQUAL.getDisplayText(), EQUAL.getDisplaySymbol(), 'dateeq', true, EQUAL.getLabKeySqlOperator()),
 
     NOT_EQUAL,
     NEQ: NOT_EQUAL,
-    DATE_NOT_EQUAL: registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'dateneq', true),
+    DATE_NOT_EQUAL: registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'dateneq', true, NOT_EQUAL.getLabKeySqlOperator()),
 
     NEQ_OR_NULL,
     NOT_EQUAL_OR_MISSING: NEQ_OR_NULL,
 
     GREATER_THAN,
     GT: GREATER_THAN,
-    DATE_GREATER_THAN: registerFilterType(GREATER_THAN.getDisplayText(), GREATER_THAN.getDisplaySymbol(), 'dategt', true),
+    DATE_GREATER_THAN: registerFilterType(GREATER_THAN.getDisplayText(), GREATER_THAN.getDisplaySymbol(), 'dategt', true, GREATER_THAN.getLabKeySqlOperator()),
 
     LESS_THAN,
     LT: LESS_THAN,
-    DATE_LESS_THAN: registerFilterType(LESS_THAN.getDisplayText(), LESS_THAN.getDisplaySymbol(), 'datelt', true),
+    DATE_LESS_THAN: registerFilterType(LESS_THAN.getDisplayText(), LESS_THAN.getDisplaySymbol(), 'datelt', true, LESS_THAN.getLabKeySqlOperator()),
 
     GREATER_THAN_OR_EQUAL,
     GTE : GREATER_THAN_OR_EQUAL,
-    DATE_GREATER_THAN_OR_EQUAL: registerFilterType(GREATER_THAN_OR_EQUAL.getDisplayText(), GREATER_THAN_OR_EQUAL.getDisplaySymbol(), 'dategte', true),
+    DATE_GREATER_THAN_OR_EQUAL: registerFilterType(GREATER_THAN_OR_EQUAL.getDisplayText(), GREATER_THAN_OR_EQUAL.getDisplaySymbol(), 'dategte', true, GREATER_THAN_OR_EQUAL.getLabKeySqlOperator()),
 
     LESS_THAN_OR_EQUAL,
     LTE: LESS_THAN_OR_EQUAL,
-    DATE_LESS_THAN_OR_EQUAL: registerFilterType(LESS_THAN_OR_EQUAL.getDisplayText(), LESS_THAN_OR_EQUAL.getDisplaySymbol(), 'datelte', true),
+    DATE_LESS_THAN_OR_EQUAL: registerFilterType(LESS_THAN_OR_EQUAL.getDisplayText(), LESS_THAN_OR_EQUAL.getDisplaySymbol(), 'datelte', true, LESS_THAN_OR_EQUAL.getLabKeySqlOperator()),
 
     STARTS_WITH: registerFilterType('Starts With', null, 'startswith', true),
     DOES_NOT_START_WITH: registerFilterType('Does Not Start With', null, 'doesnotstartwith', true),
@@ -101,8 +103,8 @@ export let Types: Record<string, IFilterType> = {
     CONTAINS: registerFilterType('Contains', null, 'contains', true),
     DOES_NOT_CONTAIN: registerFilterType('Does Not Contain', null, 'doesnotcontain', true),
 
-    CONTAINS_ONE_OF: registerFilterType('Contains One Of', null, 'containsoneof', true, ';', 'Contains One Of (example usage: a;b;c)'),
-    CONTAINS_NONE_OF: registerFilterType('Does Not Contain Any Of', null, 'containsnoneof', true, ';', 'Does Not Contain Any Of (example usage: a;b;c)'),
+    CONTAINS_ONE_OF: registerFilterType('Contains One Of', null, 'containsoneof', true, null, ';', 'Contains One Of (example usage: a;b;c)'),
+    CONTAINS_NONE_OF: registerFilterType('Does Not Contain Any Of', null, 'containsnoneof', true, null, ';', 'Does Not Contain Any Of (example usage: a;b;c)'),
 
     // NOTE: for some reason IN is aliased as EQUALS_ONE_OF. Not sure if this is for legacy purposes or it was
     // determined EQUALS_ONE_OF was a better phrase to follow this pattern I did the same for IN_OR_MISSING
@@ -112,14 +114,14 @@ export let Types: Record<string, IFilterType> = {
     NOT_IN,
     EQUALS_NONE_OF: NOT_IN,
 
-    BETWEEN: registerFilterType('Between', null, 'between', true, ',', 'Between, Inclusive (example usage: -4,4)', 2, 2),
-    NOT_BETWEEN: registerFilterType('Not Between', null, 'notbetween', true, ',', 'Not Between, Exclusive (example usage: -4,4)', 2, 2),
+    BETWEEN: registerFilterType('Between', null, 'between', true, null,  ',', 'Between, Inclusive (example usage: -4,4)', 2, 2),
+    NOT_BETWEEN: registerFilterType('Not Between', null, 'notbetween', true, null,  ',', 'Not Between, Exclusive (example usage: -4,4)', 2, 2),
 
-    MEMBER_OF: registerFilterType('Member Of', null, 'memberof', true, undefined, 'Member Of'),
+    MEMBER_OF: registerFilterType('Member Of', null, 'memberof', true, null,  undefined, 'Member Of'),
 
-    EXP_CHILD_OF: registerFilterType('Is Child Of', null, 'exp:childof', true, undefined, ' is child of'),
-    EXP_PARENT_OF: registerFilterType('Is Parent Of', null, 'exp:parentof', true, undefined, ' is parent of'),
-    EXP_LINEAGE_OF: registerFilterType('In The Lineage Of', null, 'exp:lineageof', true, ',', ' in the lineage of'),
+    EXP_CHILD_OF: registerFilterType('Is Child Of', null, 'exp:childof', true, null,  undefined, ' is child of'),
+    EXP_PARENT_OF: registerFilterType('Is Parent Of', null, 'exp:parentof', true, null, undefined, ' is parent of'),
+    EXP_LINEAGE_OF: registerFilterType('In The Lineage Of', null, 'exp:lineageof', true, null, ',', ' in the lineage of'),
 
     //
     // These are the 'no data value' operators
@@ -129,10 +131,10 @@ export let Types: Record<string, IFilterType> = {
     // The result is a filter that is encoded as "<dataRegionName>.<columnName>~=".
     HAS_ANY_VALUE: registerFilterType('Has Any Value', null, ''),
 
-    ISBLANK: registerFilterType('Is Blank', null, 'isblank'),
-    MISSING: registerFilterType('Is Blank', null, 'isblank'),
-    NONBLANK: registerFilterType('Is Not Blank', null, 'isnonblank'),
-    NOT_MISSING: registerFilterType('Is Not Blank', null, 'isnonblank'),
+    ISBLANK: registerFilterType('Is Blank', null, 'isblank', false, 'IS NULL'),
+    MISSING: registerFilterType('Is Blank', null, 'isblank', false, 'IS NULL'),
+    NONBLANK: registerFilterType('Is Not Blank', null, 'isnonblank', false, 'IS NOT NULL'),
+    NOT_MISSING: registerFilterType('Is Not Blank', null, 'isnonblank', false, 'IS NOT NULL'),
 
     HAS_MISSING_VALUE: registerFilterType('Has a missing value indicator', null, 'hasmvvalue'),
     DOES_NOT_HAVE_MISSING_VALUE: registerFilterType('Does not have a missing value indicator', null, 'nomvvalue'),
@@ -140,7 +142,7 @@ export let Types: Record<string, IFilterType> = {
     //
     // Table/Query-wise operators
     //
-    Q: registerFilterType('Search', null, 'q', true, undefined, 'Search across all columns', undefined, undefined, true),
+    Q: registerFilterType('Search', null, 'q', true, null, undefined, 'Search across all columns', undefined, undefined, true),
     //
     // Ontology operators
     //
@@ -231,7 +233,7 @@ export function getFilterTypesForType(jsonType: JsonType, mvEnabled?: boolean): 
  */
 export function registerFilterType(
     displayText: string, displaySymbol?: string, urlSuffix?: string,
-    dataValueRequired?: boolean, multiValueSeparator?: string, longDisplayText?: string,
+    dataValueRequired?: boolean, labkeySqlOperator?: string, multiValueSeparator?: string, longDisplayText?: string,
     minOccurs?: number, maxOccurs?: number, tableWise?: boolean
 ): IFilterType {
     const isDataValueRequired = () => dataValueRequired === true;
@@ -323,6 +325,10 @@ export function registerFilterType(
             } else {
                 return validate(jsonType, value, columnName);
             }
+        },
+
+        getLabKeySqlOperator: () : string => {
+            return labkeySqlOperator;
         }
     };
 

--- a/src/test/data/filter_types_snapshot.json
+++ b/src/test/data/filter_types_snapshot.json
@@ -2,7 +2,7 @@
   "BETWEEN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Between",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Between, Inclusive (example usage: -4,4)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": 2,
@@ -36,7 +36,7 @@
   "CONTAINS_NONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Contain Any Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does Not Contain Any Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -53,7 +53,7 @@
   "CONTAINS_ONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Contains One Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Contains One Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -240,7 +240,7 @@
   "EQUALS_NONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Equal Any Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does Not Equal Any Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -257,7 +257,7 @@
   "EQUALS_ONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Equals One Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Equals One Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -274,7 +274,7 @@
   "EXP_CHILD_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Child Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": " is child of",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -291,7 +291,7 @@
   "EXP_PARENT_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Parent Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": " is parent of",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -308,7 +308,7 @@
   "EXP_LINEAGE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "In The Lineage Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": " in the lineage of",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -427,7 +427,7 @@
   "IN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Equals One Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Equals One Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -529,7 +529,7 @@
   "MEMBER_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Member Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Member Of",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -580,7 +580,7 @@
   "NEQ_OR_NULL": {
     "getDisplaySymbol": "<>",
     "getDisplayText": "Does Not Equal",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does Not Equal",
     "getMultiValueFilter": "notin",
     "getMultiValueMaxOccurs": "undefined",
@@ -614,7 +614,7 @@
   "NOT_BETWEEN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Not Between",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Not Between, Exclusive (example usage: -4,4)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": 2,
@@ -648,7 +648,7 @@
   "NOT_EQUAL_OR_MISSING": {
     "getDisplaySymbol": "<>",
     "getDisplayText": "Does Not Equal",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does Not Equal",
     "getMultiValueFilter": "notin",
     "getMultiValueMaxOccurs": "undefined",
@@ -665,7 +665,7 @@
   "NOT_IN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Equal Any Of",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does Not Equal Any Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -733,7 +733,7 @@
   "Q": {
     "getDisplaySymbol": null,
     "getDisplayText": "Search",
-    "getLabKeySqlOperator": null,
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Search across all columns",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",

--- a/src/test/data/filter_types_snapshot.json
+++ b/src/test/data/filter_types_snapshot.json
@@ -2,6 +2,7 @@
   "BETWEEN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Between",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Between, Inclusive (example usage: -4,4)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": 2,
@@ -18,6 +19,7 @@
   "CONTAINS": {
     "getDisplaySymbol": null,
     "getDisplayText": "Contains",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Contains",
     "getMultiValueFilter": "containsoneof",
     "getMultiValueMaxOccurs": "undefined",
@@ -34,6 +36,7 @@
   "CONTAINS_NONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Contain Any Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Does Not Contain Any Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -50,6 +53,7 @@
   "CONTAINS_ONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Contains One Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Contains One Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -66,6 +70,7 @@
   "DATE_EQUAL": {
     "getDisplaySymbol": "=",
     "getDisplayText": "Equals",
+    "getLabKeySqlOperator": "=",
     "getLongDisplayText": "Equals",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -82,6 +87,7 @@
   "DATE_GREATER_THAN": {
     "getDisplaySymbol": ">",
     "getDisplayText": "Is Greater Than",
+    "getLabKeySqlOperator": ">",
     "getLongDisplayText": "Is Greater Than",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -98,6 +104,7 @@
   "DATE_GREATER_THAN_OR_EQUAL": {
     "getDisplaySymbol": ">=",
     "getDisplayText": "Is Greater Than or Equal To",
+    "getLabKeySqlOperator": ">=",
     "getLongDisplayText": "Is Greater Than or Equal To",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -114,6 +121,7 @@
   "DATE_LESS_THAN": {
     "getDisplaySymbol": "<",
     "getDisplayText": "Is Less Than",
+    "getLabKeySqlOperator": "<",
     "getLongDisplayText": "Is Less Than",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -130,6 +138,7 @@
   "DATE_LESS_THAN_OR_EQUAL": {
     "getDisplaySymbol": "=<",
     "getDisplayText": "Is Less Than or Equal To",
+    "getLabKeySqlOperator": "<=",
     "getLongDisplayText": "Is Less Than or Equal To",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -146,6 +155,7 @@
   "DATE_NOT_EQUAL": {
     "getDisplaySymbol": "<>",
     "getDisplayText": "Does Not Equal",
+    "getLabKeySqlOperator": "<>",
     "getLongDisplayText": "Does Not Equal",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -162,6 +172,7 @@
   "DOES_NOT_CONTAIN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Contain",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does Not Contain",
     "getMultiValueFilter": "containsnoneof",
     "getMultiValueMaxOccurs": "undefined",
@@ -178,6 +189,7 @@
   "DOES_NOT_HAVE_MISSING_VALUE": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does not have a missing value indicator",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does not have a missing value indicator",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -194,6 +206,7 @@
   "DOES_NOT_START_WITH": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Start With",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Does Not Start With",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -210,6 +223,7 @@
   "EQUAL": {
     "getDisplaySymbol": "=",
     "getDisplayText": "Equals",
+    "getLabKeySqlOperator": "=",
     "getLongDisplayText": "Equals",
     "getMultiValueFilter": "in",
     "getMultiValueMaxOccurs": "undefined",
@@ -226,6 +240,7 @@
   "EQUALS_NONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Equal Any Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Does Not Equal Any Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -242,6 +257,7 @@
   "EQUALS_ONE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Equals One Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Equals One Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -258,6 +274,7 @@
   "EXP_CHILD_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Child Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": " is child of",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -274,6 +291,7 @@
   "EXP_PARENT_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Parent Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": " is parent of",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -290,6 +308,7 @@
   "EXP_LINEAGE_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "In The Lineage Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": " in the lineage of",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -306,6 +325,7 @@
   "GREATER_THAN": {
     "getDisplaySymbol": ">",
     "getDisplayText": "Is Greater Than",
+    "getLabKeySqlOperator": ">",
     "getLongDisplayText": "Is Greater Than",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -322,6 +342,7 @@
   "GREATER_THAN_OR_EQUAL": {
     "getDisplaySymbol": ">=",
     "getDisplayText": "Is Greater Than or Equal To",
+    "getLabKeySqlOperator": ">=",
     "getLongDisplayText": "Is Greater Than or Equal To",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -338,6 +359,7 @@
   "GT": {
     "getDisplaySymbol": ">",
     "getDisplayText": "Is Greater Than",
+    "getLabKeySqlOperator": ">",
     "getLongDisplayText": "Is Greater Than",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -354,6 +376,7 @@
   "GTE": {
     "getDisplaySymbol": ">=",
     "getDisplayText": "Is Greater Than or Equal To",
+    "getLabKeySqlOperator": ">=",
     "getLongDisplayText": "Is Greater Than or Equal To",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -370,6 +393,7 @@
   "HAS_ANY_VALUE": {
     "getDisplaySymbol": null,
     "getDisplayText": "Has Any Value",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Has Any Value",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -386,6 +410,7 @@
   "HAS_MISSING_VALUE": {
     "getDisplaySymbol": null,
     "getDisplayText": "Has a missing value indicator",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Has a missing value indicator",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -402,6 +427,7 @@
   "IN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Equals One Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Equals One Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -418,6 +444,7 @@
   "ISBLANK": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Blank",
+    "getLabKeySqlOperator": "IS NULL",
     "getLongDisplayText": "Is Blank",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -434,6 +461,7 @@
   "LESS_THAN": {
     "getDisplaySymbol": "<",
     "getDisplayText": "Is Less Than",
+    "getLabKeySqlOperator": "<",
     "getLongDisplayText": "Is Less Than",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -450,6 +478,7 @@
   "LESS_THAN_OR_EQUAL": {
     "getDisplaySymbol": "=<",
     "getDisplayText": "Is Less Than or Equal To",
+    "getLabKeySqlOperator": "<=",
     "getLongDisplayText": "Is Less Than or Equal To",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -466,6 +495,7 @@
   "LT": {
     "getDisplaySymbol": "<",
     "getDisplayText": "Is Less Than",
+    "getLabKeySqlOperator": "<",
     "getLongDisplayText": "Is Less Than",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -482,6 +512,7 @@
   "LTE": {
     "getDisplaySymbol": "=<",
     "getDisplayText": "Is Less Than or Equal To",
+    "getLabKeySqlOperator": "<=",
     "getLongDisplayText": "Is Less Than or Equal To",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -498,6 +529,7 @@
   "MEMBER_OF": {
     "getDisplaySymbol": null,
     "getDisplayText": "Member Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Member Of",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -514,6 +546,7 @@
   "MISSING": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Blank",
+    "getLabKeySqlOperator": "IS NULL",
     "getLongDisplayText": "Is Blank",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -530,6 +563,7 @@
   "NEQ": {
     "getDisplaySymbol": "<>",
     "getDisplayText": "Does Not Equal",
+    "getLabKeySqlOperator": "<>",
     "getLongDisplayText": "Does Not Equal",
     "getMultiValueFilter": "notin",
     "getMultiValueMaxOccurs": "undefined",
@@ -546,6 +580,7 @@
   "NEQ_OR_NULL": {
     "getDisplaySymbol": "<>",
     "getDisplayText": "Does Not Equal",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Does Not Equal",
     "getMultiValueFilter": "notin",
     "getMultiValueMaxOccurs": "undefined",
@@ -562,6 +597,7 @@
   "NONBLANK": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Not Blank",
+    "getLabKeySqlOperator": "IS NOT NULL",
     "getLongDisplayText": "Is Not Blank",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -578,6 +614,7 @@
   "NOT_BETWEEN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Not Between",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Not Between, Exclusive (example usage: -4,4)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": 2,
@@ -594,6 +631,7 @@
   "NOT_EQUAL": {
     "getDisplaySymbol": "<>",
     "getDisplayText": "Does Not Equal",
+    "getLabKeySqlOperator": "<>",
     "getLongDisplayText": "Does Not Equal",
     "getMultiValueFilter": "notin",
     "getMultiValueMaxOccurs": "undefined",
@@ -610,6 +648,7 @@
   "NOT_EQUAL_OR_MISSING": {
     "getDisplaySymbol": "<>",
     "getDisplayText": "Does Not Equal",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Does Not Equal",
     "getMultiValueFilter": "notin",
     "getMultiValueMaxOccurs": "undefined",
@@ -626,6 +665,7 @@
   "NOT_IN": {
     "getDisplaySymbol": null,
     "getDisplayText": "Does Not Equal Any Of",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Does Not Equal Any Of (example usage: a;b;c)",
     "getMultiValueFilter": null,
     "getMultiValueMaxOccurs": "undefined",
@@ -642,6 +682,7 @@
   "NOT_MISSING": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Not Blank",
+    "getLabKeySqlOperator": "IS NOT NULL",
     "getLongDisplayText": "Is Not Blank",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -658,6 +699,7 @@
   "ONTOLOGY_IN_SUBTREE": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is In Subtree",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Is In Subtree",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -674,6 +716,7 @@
   "ONTOLOGY_NOT_IN_SUBTREE": {
     "getDisplaySymbol": null,
     "getDisplayText": "Is Not In Subtree",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Is Not In Subtree",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -690,6 +733,7 @@
   "Q": {
     "getDisplaySymbol": null,
     "getDisplayText": "Search",
+    "getLabKeySqlOperator": null,
     "getLongDisplayText": "Search across all columns",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",
@@ -706,6 +750,7 @@
   "STARTS_WITH": {
     "getDisplaySymbol": null,
     "getDisplayText": "Starts With",
+    "getLabKeySqlOperator": "undefined",
     "getLongDisplayText": "Starts With",
     "getMultiValueFilter": "undefined",
     "getMultiValueMaxOccurs": "undefined",


### PR DESCRIPTION
#### Rationale
To support lineage queries with the new EXPDESCENDANTSOF operator, we need to be able to generate LabKey sql from LABKEY.Query.Filter. This PR adds getLabKeySqlOperator to IFilterType, which ui-components then utilize to generate such sql.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/124
* https://github.com/LabKey/labkey-ui-components/pull/743
* https://github.com/LabKey/sampleManagement/pull/847
* https://github.com/LabKey/biologics/pull/1165

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
