### PR TITLE
ActionURL.getPathFromLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.0 - 2022-04-28
+- Export `ActionURL.getPathFromLocation()` and update to accept input parameters for `pathname` and `contextPath`.
+- Add `contextPath` as a part of the return value from `ActionURL.getPathFromLocation()`.
+- Export `Project` interface.
+
 ## 1.10.0 - 2022-02-28
 - Add getLabKeySqlOperator to IFilterType
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2420,8 +2420,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3762,7 +3761,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.4.0",
         "jest-serializer": "^27.4.0",
@@ -4978,9 +4976,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-url-path-location.2",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.10.0-fb-url-path-location.2",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-url-path-location.1",
+  "version": "1.10.0-fb-url-path-location.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.10.0-fb-url-path-location.1",
+      "version": "1.10.0-fb-url-path-location.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-url-path-location.0",
+  "version": "1.10.0-fb-url-path-location.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.10.0-fb-url-path-location.0",
+      "version": "1.10.0-fb-url-path-location.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0",
+  "version": "1.10.0-fb-url-path-location.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.10.0",
+      "version": "1.10.0-fb-url-path-location.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",
@@ -2420,7 +2420,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3761,6 +3762,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.4.0",
         "jest-serializer": "^27.4.0",
@@ -4976,6 +4978,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -8041,8 +8046,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
       "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.4.0",
@@ -8057,8 +8061,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
       "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -8106,8 +8109,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -8140,8 +8142,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -9976,8 +9977,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -11979,8 +11979,7 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-url-path-location.1",
+  "version": "1.10.0-fb-url-path-location.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-url-path-location.0",
+  "version": "1.10.0-fb-url-path-location.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0",
+  "version": "1.10.0-fb-url-path-location.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0-fb-url-path-location.2",
+  "version": "1.11.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
     ExperimentalFlags,
     LabKey,
     getServerContext,
+    Project,
     User,
     UserWithPermissions,
 } from './labkey/constants';
@@ -69,6 +70,7 @@ export {
     /* interfaces */
     Container,
     ExperimentalFlags,
+    Project,
 
     /* modules */
     ActionURL,

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as ActionURL from './ActionURL';
-import {getServerContext} from "./constants";
+import { getServerContext } from './constants';
 
 describe('ActionURL', () => {
 
@@ -71,11 +71,13 @@ describe('ActionURL', () => {
             validatePath('/home/project-begin.view', '', '/home', 'project', 'begin');
             validatePath('/home/with/folder/project-begin.view', '', '/home/with/folder', 'project', 'begin');
             validatePath('/%E2%98%83/%E2%9D%86/%E2%A8%8Drosty-%F0%9D%95%8Anow.view', '', '/☃/❆', '⨍rosty', '𝕊now');
+            validatePath('/my%20folder/my%20path/pipeline-status-action.view?rowId=123', '', '/my folder/my path', 'pipeline-status', 'action');
 
             // old style URL
             validatePath('/project/home/begin.view', '', '/home', 'project', 'begin');
             validatePath('/project/home/with/folder/begin.view', '', '/home/with/folder', 'project', 'begin');
             validatePath('/%E2%A8%8Drosty/%E2%98%83/%E2%9D%86/%F0%9D%95%8Anow.view', '', '/☃/❆', '⨍rosty', '𝕊now');
+            validatePath('/pipeline-status/my%20folder/my%20path/action.view?rowId=123', '', '/my folder/my path', 'pipeline-status', 'action');
         });
 
         test('with context path', () => {
@@ -85,10 +87,12 @@ describe('ActionURL', () => {
             // new style URL
             validatePath(`${contextPath}/1/project-begin.view`, contextPath, '/1', 'project', 'begin');
             validatePath(`${contextPath}/1/2/3/project-begin.view`, contextPath, '/1/2/3', 'project', 'begin');
+            validatePath(`${contextPath}/my%20folder/my%20path/pipeline-status-action.view?rowId=123`, contextPath, '/my folder/my path', 'pipeline-status', 'action');
 
             // old style URL
             validatePath(`${contextPath}/project/home/begin.view`, contextPath, '/home', 'project', 'begin');
             validatePath(`${contextPath}/project/home/with/folder/begin.view`, contextPath, '/home/with/folder', 'project', 'begin');
+            validatePath(`${contextPath}/pipeline-status/my%20folder/my%20path/action.view?rowId=123`, contextPath, '/my folder/my path', 'pipeline-status', 'action');
         });
     });
 });

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as sinon from 'sinon';
 import * as ActionURL from './ActionURL';
+import {getServerContext} from "./constants";
 
 describe('ActionURL', () => {
 
@@ -50,5 +50,45 @@ describe('ActionURL', () => {
         //     expect(containerName).toEqual(CONTAINER_NAME);
         //     stub.restore();
         // });
+    });
+
+    describe('getPathFromLocation', () => {
+        function validatePath(pathname: string, contextPath: string, containerPath: string, controller: string, action: string): void {
+            const path = ActionURL.getPathFromLocation(pathname);
+
+            expect(path.contextPath).toEqual(contextPath);
+            expect(path.containerPath).toEqual(containerPath);
+            expect(path.controller).toEqual(controller);
+            expect(path.action).toEqual(action);
+        }
+
+        afterEach(() => {
+            getServerContext().contextPath = '';
+        });
+
+        test('without context path', () => {
+            // new style URL
+            validatePath('/home/project-begin.view', '', '/home', 'project', 'begin');
+            validatePath('/home/with/folder/project-begin.view', '', '/home/with/folder', 'project', 'begin');
+            validatePath('/%E2%98%83/%E2%9D%86/%E2%A8%8Drosty-%F0%9D%95%8Anow.view', '', '/☃/❆', '⨍rosty', '𝕊now');
+
+            // old style URL
+            validatePath('/project/home/begin.view', '', '/home', 'project', 'begin');
+            validatePath('/project/home/with/folder/begin.view', '', '/home/with/folder', 'project', 'begin');
+            validatePath('/%E2%A8%8Drosty/%E2%98%83/%E2%9D%86/%F0%9D%95%8Anow.view', '', '/☃/❆', '⨍rosty', '𝕊now');
+        });
+
+        test('with context path', () => {
+            const contextPath = '/myContextPath';
+            getServerContext().contextPath = contextPath;
+
+            // new style URL
+            validatePath(`${contextPath}/1/project-begin.view`, contextPath, '/1', 'project', 'begin');
+            validatePath(`${contextPath}/1/2/3/project-begin.view`, contextPath, '/1/2/3', 'project', 'begin');
+
+            // old style URL
+            validatePath(`${contextPath}/project/home/begin.view`, contextPath, '/home', 'project', 'begin');
+            validatePath(`${contextPath}/project/home/with/folder/begin.view`, contextPath, '/home/with/folder', 'project', 'begin');
+        });
     });
 });

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -306,30 +306,35 @@ export interface ActionPath {
 export function getPathFromLocation(pathname?: string, contextPath?: string): ActionPath {
     const ctxPath = contextPath ?? getContextPath();
     const start = ctxPath ? ctxPath.length : 0;
-
     let path = pathname ?? getLocation().pathname;
-    const end = path.lastIndexOf('/');
 
+    const qMarkIdx = path.indexOf('?');
+    if (qMarkIdx > -1) {
+        path = path.substring(0, qMarkIdx);
+    }
+
+    const end = path.lastIndexOf('/');
     let action = path.substring(end + 1);
     path = path.substring(start, end);
 
-    let controller: string;
-    const dash = action.indexOf('-');
+    let controller;
 
-    if (0 < dash) {
+    const dash = action.lastIndexOf('-');
+    if (dash > 0) {
         controller = action.substring(0, dash);
         action = action.substring(dash + 1);
     } else {
-        let slash = path.indexOf('/', 1);
-        if (slash < 0) // Issue 21945: e.g. '/admin'
+        const slash = path.indexOf('/', 1);
+        if (slash < 0) { // 21945: e.g. '/admin'
             controller = path.substring(1);
-        else
+        } else {
             controller = path.substring(1, slash);
+        }
         path = path.substring(slash);
     }
 
     const dot = action.indexOf('.');
-    if (0 < dot) {
+    if (dot > 0) {
         action = action.substring(0, dot);
     }
 

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -264,6 +264,83 @@ export function getParameters(url?: string): {[key:string]: any} {
     return buildParameterMap(paramString);
 }
 
+export interface ActionPath {
+    action: string;
+    containerPath: string;
+    contextPath: string;
+    controller: string;
+}
+
+/**
+ * Parses a location pathname of a LabKey URL into its constituent parts (e.g. controller, action, etc).
+ * Defaults to the current location's pathname and context path. The parsed parts of the [[ActionPath]] are
+ * URI decoded.
+ * #### Example
+ *
+ * ```
+ * // 1. First example shows the default values as retrieved for the pathname and context path.
+ * // window.location.pathname = "/labkey/folder/tree/study-participants.view"
+ * // LABKEY.contextPath = "/labkey"
+ * const path = ActionURL.getPathFromLocation();
+ *
+ * console.log(path.contextPath);   // "/labkey"
+ * console.log(path.containerPath); // "/folder/tree"
+ * console.log(path.controller);    // "study"
+ * console.log(path.action);        // "participants"
+ *
+ * // 2. Second example when the "pathname" parameter is supplied. The default value for context path is utilized.
+ * // LABKEY.contextPath = "/labkey"
+ * const pathname = "/labkey/home/with/folder/project-begin.view";
+ * const path = ActionURL.getPathFromLocation(pathname);
+ *
+ * console.log(path.contextPath);   // "/labkey"
+ * console.log(path.containerPath); // "/home/with/folder"
+ * console.log(path.controller);    // "project"
+ * console.log(path.action);        // "begin"
+ * ```
+ * @param pathname A pathname to parse. Defaults to value of window.location.pathname.
+ * **Note:** This function does not parse full URLs. It expects only the value that would be part of the "pathname"
+ * on window.location. See https://html.spec.whatwg.org/multipage/history.html#dom-location-pathname.
+ * @param contextPath A context path to parse. Defaults to value returned by [[getContextPath]].
+ */
+export function getPathFromLocation(pathname?: string, contextPath?: string): ActionPath {
+    const ctxPath = contextPath ?? getContextPath();
+    const start = ctxPath ? ctxPath.length : 0;
+
+    let path = pathname ?? getLocation().pathname;
+    const end = path.lastIndexOf('/');
+
+    let action = path.substring(end + 1);
+    path = path.substring(start, end);
+
+    let controller: string;
+    const dash = action.indexOf('-');
+
+    if (0 < dash) {
+        controller = action.substring(0, dash);
+        action = action.substring(dash + 1);
+    } else {
+        let slash = path.indexOf('/', 1);
+        if (slash < 0) // Issue 21945: e.g. '/admin'
+            controller = path.substring(1);
+        else
+            controller = path.substring(1, slash);
+        path = path.substring(slash);
+    }
+
+    const dot = action.indexOf('.');
+    if (0 < dot) {
+        action = action.substring(0, dot);
+    }
+
+    return {
+        action: decodeURIComponent(action),
+        containerPath: decodeURI(path),
+        contextPath: decodeURIComponent(ctxPath),
+        controller: decodeURIComponent(controller),
+    }
+}
+
 /**
  * Get the 'returnUrl' parameter from the URL.
  */
@@ -321,64 +398,10 @@ export function queryString(parameters?: {[key:string]: string | Array<string>})
  * @hidden
  * @private
  */
-interface ActionPath {
-    controller: string
-    action: string
-    containerPath: string
-}
-
-/**
- * @hidden
- * @private
- */
 function codePath(path: string, method: (v: string) => string): string {
     let a = path.split('/');
     for (let i=0; i < a.length; i++) {
         a[i] = method(a[i]);
     }
     return a.join('/');
-}
-
-// Formerly, parsePathName
-/**
- * @hidden
- * @private
- */
-function getPathFromLocation(): ActionPath {
-
-    const { contextPath } = getServerContext();
-    const start = contextPath ? contextPath.length : 0;
-
-    let path = getLocation().pathname;
-    const end = path.lastIndexOf('/');
-
-    let action = path.substring(end + 1);
-    path = path.substring(start, end);
-
-    let controller: string = null;
-    let dash = action.indexOf('-');
-
-    if (0 < dash) {
-        controller = action.substring(0, dash);
-        action = action.substring(dash + 1);
-    }
-    else {
-        let slash = path.indexOf('/', 1);
-        if (slash < 0) // 21945: e.g. '/admin'
-            controller = path.substring(1);
-        else
-            controller = path.substring(1, slash);
-        path = path.substring(slash);
-    }
-
-    let dot = action.indexOf('.');
-    if (0 < dot) {
-        action = action.substring(0, dot);
-    }
-
-    return {
-        controller: decodeURIComponent(controller),
-        action: decodeURIComponent(action),
-        containerPath: decodeURI(path)
-    }
 }


### PR DESCRIPTION
#### Rationale
This PR makes `ActionURL.getPathFromLocation()` available for use to external users. This utility method is useful for parsing LKS-specific URLs. It has been in our client code for awhile, however, it was not publicly available so we started to have duplicate implementations (namely, `parsePathName` in `@labkey/components`). This pays down this technical debt and updates the method to accept input parameters beyond parsing from the current location.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/126
* https://github.com/LabKey/labkey-ui-components/pull/824

#### Changes
* Export `ActionURL.getPathFromLocation()` and update to accept input parameters for `pathname` and `contextPath`.
* Add `contextPath` as a part of the return value from `ActionURL.getPathFromLocation()`.
* Export `Project` interface.
