### PR TITLE
Enable reading error messages when requesting downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD
+- Adjust request to enable reading error messages on failed downloads
+
 ## 1.10.0 - 2022-02-28
 - Add getLabKeySqlOperator to IFilterType
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD
+## 1.12.0 - 2022-05-03
 - Adjust request to enable reading error messages on failed downloads
 
 ## 1.11.0 - 2022-04-28

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0",
+  "version": "1.10.0-fb-downloadError.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.10.0",
+      "version": "1.10.0-fb-downloadError.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",
@@ -8041,8 +8041,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
       "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.4.0",
@@ -8057,8 +8056,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
       "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -8106,8 +8104,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -8140,8 +8137,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -9976,8 +9972,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -11979,8 +11974,7 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.11.0-fb-downloadError.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.11.0-fb-downloadError.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.11.0-fb-downloadError.0",
+  "version": "1.12.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.10.0",
+  "version": "1.10.0-fb-downloadError.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -306,6 +306,12 @@ export function request(config: RequestOptions): XMLHttpRequest {
 
             callback(success ? config.success : config.failure, scope, [xhr, config]);
             callback(config.callback, scope, [config, success, xhr]);
+        } else if (xhr.readyState === 2 && xhr.responseType === 'blob' ) {
+            // Change response type of download requests to allow reading any error messages upon failure
+            let success = (xhr.status >= 200 && xhr.status < 300) || xhr.status == 304;
+            if (!success) {
+                xhr.responseType = 'text';
+            }
         }
     };
 


### PR DESCRIPTION
#### Rationale
When making a download, we currently can't read any error messages as the content type is incorrect

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/814

#### Changes
* Update the Ajax.request onreadystatechange handler to adjust the expected response content type for failed downloads
