### PR TITLE
Issue 45270: We require the AdminOperationPermission to check for certain panels on the LKB settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.12.TBD - TBD
+- Issue 45270: Add AdminOperationsPermission
+
 ## 1.12.1 - 2022-05-13
 - Issue 45091: savePolicy update to support unwrapped policy object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.12.TBD - TBD
+## 1.13.0 - 2022-05-31
 - Issue 45270: Add AdminOperationsPermission
 
 ## 1.12.1 - 2022-05-13

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.12.2-settingsForAllAdmins.0",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.12.2-settingsForAllAdmins.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.12.1",
+  "version": "1.12.2-settingsForAllAdmins.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.12.1",
+      "version": "1.12.2-settingsForAllAdmins.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.12.2-settingsForAllAdmins.0",
+  "version": "1.13.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.12.1",
+  "version": "1.12.2-settingsForAllAdmins.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/constants.ts
+++ b/src/labkey/security/constants.ts
@@ -50,6 +50,7 @@ export enum PermissionTypes {
 
     // Other
     AddUser = 'org.labkey.api.security.permissions.AddUserPermission',
+    AdminOperationsPermission = 'org.labkey.api.security.permissions.AdminOperationsPermission',
     ApplicationAdmin = 'org.labkey.api.security.permissions.ApplicationAdminPermission',
     CanSeeAuditLog = 'org.labkey.api.audit.permissions.CanSeeAuditLogPermission',
     DesignAssay = 'org.labkey.api.assay.security.DesignAssayPermission',


### PR DESCRIPTION
#### Rationale
We are allowing any admins to see the Settings page in our applications, and so need more permission checks for individual panels, one of which is available via `AdminOperationsPermission`

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/848
* https://github.com/LabKey/biologics/pull/1340

#### Changes
* add `AdminOperationsPermission` as a `PermissionType`
