### PR TITLE
Add PrimaryStorage as new storage type for non-temperature-controlled storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## TBD - TBD
-- Add PrimaryStorage as a new STORAGE_TYPE equivalent to Freezer from room-temp storage
+- Add PrimaryStorage as a new STORAGE_TYPE equivalent to Freezer for room-temp storage
 
 ## 1.16.1 - 2022-09-22
 - Add `PermissionRoles.EditorWithoutDelete`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Add PrimaryStorage as a new STORAGE_TYPE equivalent to Freezer from room-temp storage
+
 ## 1.16.1 - 2022-09-22
 - Add `PermissionRoles.EditorWithoutDelete`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.17.0 - 2022-12-15
 - Add PrimaryStorage as a new STORAGE_TYPE equivalent to Freezer for room-temp storage
 
 ## 1.16.1 - 2022-09-22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.16.1",
+  "version": "1.16.2-freezerToStorage.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.16.1",
+      "version": "1.16.2-freezerToStorage.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.16.2-freezerToStorage.0",
+  "version": "1.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.16.2-freezerToStorage.0",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.16.2-freezerToStorage.0",
+  "version": "1.17.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.16.1",
+  "version": "1.16.2-freezerToStorage.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Storage.ts
+++ b/src/labkey/Storage.ts
@@ -31,13 +31,14 @@ export interface IStorageCommandOptions extends RequestCallbackOptions<StorageCo
     containerPath?: string;
     /** The specific set of props will differ for each storage item type:
      * - Physical Location: name, description, locationId (rowId of the parent Physical Location)
+     * - Primary Storage: name, description, locationId (rowId of the parent Physical Location)
      * - Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status
      * - Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)
      * - Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")
      * - Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)
      */
     props: Record<string, any>;
-    /** Storage items can be of the following types: Physical Location, Freezer, Shelf, Rack, Canister, Storage Unit Type, or Terminal Storage Location. */
+    /** Storage items can be of the following types: Physical Location, Freezer, Primary Storage, Shelf, Rack, Canister, Storage Unit Type, or Terminal Storage Location. */
     type: STORAGE_TYPES;
 }
 
@@ -217,6 +218,7 @@ export function deleteStorageItem(config: DeleteStorageCommandOptions): XMLHttpR
 enum STORAGE_TYPES {
     PhysicalLocation = 'Physical Location',
     Freezer = 'Freezer',
+    PrimaryStorage = 'Primary Storage',
     Shelf = 'Shelf',
     Rack = 'Rack',
     Canister = 'Canister',

--- a/src/labkey/Storage.ts
+++ b/src/labkey/Storage.ts
@@ -31,8 +31,8 @@ export interface IStorageCommandOptions extends RequestCallbackOptions<StorageCo
     containerPath?: string;
     /** The specific set of props will differ for each storage item type:
      * - Physical Location: name, description, locationId (rowId of the parent Physical Location)
-     * - Primary Storage: name, description, locationId (rowId of the parent Physical Location)
-     * - Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status
+     * - Primary Storage: name, description, locationId (rowId of the parent Physical Location), temperatureControlled (boolean)
+     * - Freezer: name, description, locationId (rowId of the parent Physical Location), manufacturer, freezerModel, temperature, temperatureUnits, serialNumber, sensorName, lossRate, status, temperatureControlled (boolean)
      * - Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)
      * - Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")
      * - Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)


### PR DESCRIPTION
#### Rationale
We want to make it more clear within the application and our APIs that our storage management capabilities can support temperature-controlled as well as room-temperature storage. Thus we're updating the language in the applications to refer to the primary storage units more generically as "Storage" instead of "Freezers".

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1055
- https://github.com/LabKey/inventory/pull/648

#### Changes
* Add `PrimaryStorage` as a new `STORAGE_TYPE` equivalent to `Freezer` from room-temp storage
