### PR TITLE
Issue 46962: Fix decoding of paths containing encoded commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Fix URI decoding for paths with encoded commas
+
 ## 1.17.0 - 2022-12-15
 - Add PrimaryStorage as a new STORAGE_TYPE equivalent to Freezer for room-temp storage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## TBD - TBD
-- Fix URI decoding for paths with encoded commas
+## 1.17.1 - 2022-12-19
+- Fix URI decoding for paths with encoded characters in container names
 
 ## 1.17.0 - 2022-12-15
 - Add PrimaryStorage as a new STORAGE_TYPE equivalent to Freezer for room-temp storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.0",
+  "version": "1.17.1-projectNameEncoding.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.17.0",
+      "version": "1.17.1-projectNameEncoding.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.1-projectNameEncoding.1",
+  "version": "1.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.17.1-projectNameEncoding.1",
+      "version": "1.17.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.1-projectNameEncoding.0",
+  "version": "1.17.1-projectNameEncoding.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.17.1-projectNameEncoding.0",
+      "version": "1.17.1-projectNameEncoding.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.1-projectNameEncoding.0",
+  "version": "1.17.1-projectNameEncoding.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.1-projectNameEncoding.1",
+  "version": "1.17.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.0",
+  "version": "1.17.1-projectNameEncoding.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -97,7 +97,7 @@ describe('ActionURL', () => {
         });
 
         test('with context path', () => {
-            const contextPath = '/myContextPath';
+            let contextPath = '/myContextPath';
             getServerContext().contextPath = contextPath;
 
             // new style URL
@@ -110,6 +110,10 @@ describe('ActionURL', () => {
                 'pipeline-status',
                 'action'
             );
+            contextPath ='/my, CommaContext';
+            getServerContext().contextPath = contextPath;
+            validatePath(`${contextPath}/1%2C%202/pro%2C%20ject-be%2C%20%2Cgin.view`, contextPath, '/1, 2', 'pro, ject', 'be, ,gin');
+            validatePath(`${contextPath}/1%2C%202%2C%203/project-begin.view`, contextPath, '/1, 2, 3', 'project', 'begin');
 
             // old style URL
             validatePath(`${contextPath}/project/home/begin.view`, contextPath, '/home', 'project', 'begin');

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -274,6 +274,16 @@ export interface ActionPath {
 }
 
 /**
+ * decodeURI chooses not to decode encoded commas (presumably because encodeURI also does nothing with commas).
+ * This can be problematic since encoding of commas is actually recommended (and done on the server side).
+ * @param uri to be decoded.
+ */
+function fullyDecodeURI(uri: string)
+{
+    return decodeURI(uri).replace(/%2C/g, ",")
+}
+
+/**
  * Parses a location pathname of a LabKey URL into its constituent parts (e.g. controller, action, etc).
  * Defaults to the current location's pathname and context path. The parsed parts of the [[ActionPath]] are
  * URI decoded.
@@ -343,7 +353,7 @@ export function getPathFromLocation(pathname?: string, contextPath?: string): Ac
 
     return {
         action: decodeURIComponent(action),
-        containerPath: decodeURI(path),
+        containerPath: fullyDecodeURI(path),
         contextPath: decodeURIComponent(ctxPath),
         controller: decodeURIComponent(controller),
     };

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -274,13 +274,22 @@ export interface ActionPath {
 }
 
 /**
- * decodeURI chooses not to decode encoded commas (presumably because encodeURI also does nothing with commas).
- * This can be problematic since encoding of commas is actually recommended (and done on the server side).
- * @param uri to be decoded.
+ * decodeURI chooses not to decode characters that are part of the URI syntax (; / ? : @ & = + $ , #).
+ * This can be problematic since we do encode these characters on the server side when they are part of the path.
+ * Here, we decode the subset of these encoded characters that can be part of a project name.
+ * @param path to be decoded.
+ * @return A new copy of the given path with all encoded characters decoded
  */
-function fullyDecodeURI(uri: string)
+function fullyDecodeURIPath(path: string): string
 {
-    return decodeURI(uri).replace(/%2C/g, ",")
+    return decodeURI(path)
+        .replace(/%2C/g, ",")
+        .replace(/%3B/g, ";")
+        .replace(/%40/g, "@")
+        .replace(/%26/g, "&")
+        .replace(/%3D/g, "=")
+        .replace(/%24/g, "$")
+        .replace(/%23/g, "#");
 }
 
 /**
@@ -353,7 +362,7 @@ export function getPathFromLocation(pathname?: string, contextPath?: string): Ac
 
     return {
         action: decodeURIComponent(action),
-        containerPath: fullyDecodeURI(path),
+        containerPath: fullyDecodeURIPath(path),
         contextPath: decodeURIComponent(ctxPath),
         controller: decodeURIComponent(controller),
     };


### PR DESCRIPTION
#### Rationale
 `decodeURI` chooses not to decode encoded commas (presumably because encodeURI also does nothing with commas) (even though `decodeURIComponent` does the right thing). This can be problematic since encoding of commas is actually recommended (and done on the server side). 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add own decodeURI method to handle decoding of commas as well.
