### PR TITLE
Add includeViewDataUrl and includeTitle parameters to Query.getQueries()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 1.18.0-pivot_perf - 2022-12-30
-- Add `includeViewDataUrl` and `includeTitle` parameters to `Query.getQueries()`. Setting these to `false` (along with existing parameter `includeColumns`) can improvement performance of these calls.
+## 1.18.0 - 2023-01-03
+- [Issue 47010](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47010): Add `includeViewDataUrl` and `includeTitle` parameters to `Query.getQueries()`. Setting these to `false` (along with existing parameter `includeColumns`) can improve performance of getQueries() calls.
 
 ## 1.17.1 - 2022-12-19
 - Fix URI decoding for paths with encoded characters in container names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.18.0-pivot_perf - 2022-12-30
+- Add `includeViewDataUrl` and `includeTitle` parameters to `Query.getQueries()`. Setting these to `false` (along with existing parameter `includeColumns`) can improvement performance of these calls.
+
 ## 1.17.1 - 2022-12-19
 - Fix URI decoding for paths with encoded characters in container names
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ can do so via the following steps:
 1. Build the package (as described above).
 1. Copy the package's `/dist` directory to `/<labkey root>/server/modules/platform/core/node_modules/@labkey/api/dist`.
 1. Navigate to `/<labkey root>/server/modules/platform/core`.
-1. Run `node build.js` from the `core` module directory.
+1. Run `npm run copy-distributions` from the `core` module directory.
 
 Your changes will now be included in the bundle served by your local LabKey Server instance.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.1",
+  "version": "1.18.0-pivot-perf.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.17.1",
+      "version": "1.18.0-pivot-perf.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.0-pivot-perf.0",
+  "version": "1.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.0-pivot-perf.0",
+      "version": "1.18.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.0-pivot_perf",
+  "version": "1.18.0-pivot-perf.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.0-pivot-perf.0",
+  "version": "1.18.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.17.1",
+  "version": "1.18.0-pivot_perf",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -245,18 +245,18 @@ export interface GetQueriesOptions extends RequestCallbackOptions<GetQueriesResp
     includeColumns?: boolean;
     /** If set to false, system-defined queries will not be included in the results. Default is true. */
     includeSystemQueries?: boolean;
+    /** If set to false, no custom query titles will be included. Instead, titles will be identical to names. Default is true. */
+    includeTitle?: boolean;
     /** If set to false, user-defined queries will not be included in the results. Default is true. */
     includeUserQueries?: boolean;
+    /** If set to false, view data URLs will not be included in the results. Default is true. */
+    includeViewDataUrl?: boolean;
     /**
      * If set to true, and includeColumns is set to true, information about the available columns
      * will be the same details as specified by [[getQueryDetails]] for columns.
      * Defaults to false.
      */
     queryDetailColumns?: boolean;
-    /** If set to false, view data URLs will not be included in the results. Default is true. */
-    includeViewDataUrl?: boolean;
-    /** If set to false, no custom query titles will be included. Instead, titles will be identical to names. Default is true. */
-    includeTitle?: boolean;
     /** The name of the schema. */
     schemaName: string;
 }
@@ -274,11 +274,11 @@ export function getQueries(options: GetQueriesOptions): XMLHttpRequest {
         {
             schemaName: 'schemaName',
             includeColumns: 'includeColumns',
-            includeUserQueries: 'includeUserQueries',
             includeSystemQueries: 'includeSystemQueries',
-            queryDetailColumns: 'queryDetailColumns',
-            includeViewDataUrl: 'includeViewDataUrl',
             includeTitle: 'includeTitle',
+            includeUserQueries: 'includeUserQueries',
+            includeViewDataUrl: 'includeViewDataUrl',
+            queryDetailColumns: 'queryDetailColumns',
         },
         false,
         false

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -253,6 +253,10 @@ export interface GetQueriesOptions extends RequestCallbackOptions<GetQueriesResp
      * Defaults to false.
      */
     queryDetailColumns?: boolean;
+    /** If set to false, view data URLs will not be included in the results. Default is true. */
+    includeViewDataUrl?: boolean;
+    /** If set to false, no custom query titles will be included. Instead, titles will be identical to names. Default is true. */
+    includeTitle?: boolean;
     /** The name of the schema. */
     schemaName: string;
 }
@@ -273,6 +277,8 @@ export function getQueries(options: GetQueriesOptions): XMLHttpRequest {
             includeUserQueries: 'includeUserQueries',
             includeSystemQueries: 'includeSystemQueries',
             queryDetailColumns: 'queryDetailColumns',
+            includeViewDataUrl: 'includeViewDataUrl',
+            includeTitle: 'includeTitle',
         },
         false,
         false


### PR DESCRIPTION
#### Rationale
Callers can set these flags to `false` (along with existing `includeColumns` flag) to improve performance of the request, particularly when PIVOT queries are involved

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3961

#### Changes
* Allow and propagate a couple new flags
