### PR TITLE
Issue 47044: Decode plus sign that may be a part of a folder path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- [Issue 47044](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47044): Decode the plus sign that may be part of a folder path
+
 ## 1.18.0 - 2023-01-03
 - [Issue 47010](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47010): Add `includeViewDataUrl` and `includeTitle` parameters to `Query.getQueries()`. Setting these to `false` (along with existing parameter `includeColumns`) can improve performance of getQueries() calls.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.18.1 - 2023-01-09
 - [Issue 47044](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47044): Decode the plus sign that may be part of a folder path
 
 ## 1.18.0 - 2023-01-03

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.0",
+  "version": "1.18.1-miscFixesSusan232.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.0",
+      "version": "1.18.1-miscFixesSusan232.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.1-miscFixesSusan232.0",
+  "version": "1.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.1-miscFixesSusan232.0",
+      "version": "1.18.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.0",
+  "version": "1.18.1-miscFixesSusan232.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.1-miscFixesSusan232.0",
+  "version": "1.18.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -75,6 +75,7 @@ describe('ActionURL', () => {
             validatePath('/home/project-begin.view', '', '/home', 'project', 'begin');
             validatePath('/home/with/folder/project-begin.view', '', '/home/with/folder', 'project', 'begin');
             validatePath('/%E2%98%83/%E2%9D%86/%E2%A8%8Drosty-%F0%9D%95%8Anow.view', '', '/☃/❆', '⨍rosty', '𝕊now');
+            validatePath('/home%2C%2B%2B%3B%40%26%3D%24%23%2Cfolder/project-begin.view', '', '/home,++;@&=$#,folder', 'project', 'begin');
             validatePath(
                 '/my%20folder/my%20path/pipeline-status-action.view?rowId=123',
                 '',

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -284,6 +284,7 @@ function fullyDecodeURIPath(path: string): string
 {
     return decodeURI(path)
         .replace(/%2C/g, ",")
+        .replace(/%2B/g, "+")
         .replace(/%3B/g, ";")
         .replace(/%40/g, "@")
         .replace(/%26/g, "&")


### PR DESCRIPTION
#### Rationale
[Issue 47044](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47044): Decode the plus sign that may be part of a folder path

#### Related Pull Requests
- #140 
- https://github.com/LabKey/labkey-ui-components/pull/1080
- https://github.com/LabKey/sampleManagement/pull/1532
- https://github.com/LabKey/labkey-ui-premium/pull/17
- https://github.com/LabKey/labbook/pull/376
- https://github.com/LabKey/biologics/pull/1852
- https://github.com/LabKey/inventory/pull/685

#### Changes
* Add plus sign to decoding characters
