### PR TITLE
Issue46344: Display group membership on profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Add `PermissionTypes.CanSeeGroupDetails`
+
 ## 1.18.1 - 2023-01-09
 - [Issue 47044](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47044): Decode the plus sign that may be part of a folder path
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.18.2 - 2023-01-20
 - Add `PermissionTypes.CanSeeGroupDetails`
 
 ## 1.18.1 - 2023-01-09

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.1-fb-issue46344.0",
+  "version": "1.18.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.1",
+  "version": "1.18.1-fb-issue46344.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/constants.ts
+++ b/src/labkey/security/constants.ts
@@ -47,6 +47,7 @@ export enum PermissionTypes {
     AdminOperationsPermission = 'org.labkey.api.security.permissions.AdminOperationsPermission',
     ApplicationAdmin = 'org.labkey.api.security.permissions.ApplicationAdminPermission',
     CanSeeAuditLog = 'org.labkey.api.audit.permissions.CanSeeAuditLogPermission',
+    CanSeeGroupDetails = 'org.labkey.api.security.permissions.SeeGroupDetailsPermission',
     Delete = 'org.labkey.api.security.permissions.DeletePermission',
     DesignAssay = 'org.labkey.api.assay.security.DesignAssayPermission',
     DesignDataClass = 'org.labkey.api.security.permissions.DesignDataClassPermission',


### PR DESCRIPTION
#### Rationale
It is desired that on a user's profile page (of url #/account/profile) we should display a new row with the title 'Groups' and then a comma-delimited, alphabetical list of groups the user belongs to _if_ they possess the permissions to see Group details.
See Issue for more detail, including manual test plan.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1084
* https://github.com/LabKey/labkey-api-js/pull/143
* https://github.com/LabKey/biologics/pull/1864
* https://github.com/LabKey/sampleManagement/pull/1548
* https://github.com/LabKey/inventory/pull/691
* https://github.com/LabKey/labkey-ui-premium/pull/22

#### Changes
* Add PermissionTypes.CanSeeGroupDetails
