### PR TITLE
Update links from users to display user detail data via modal for those who have permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Add `PermissionTypes.CanSeeUserDetails`
+
 ## 1.18.2 - 2023-01-20
 - Add `PermissionTypes.CanSeeGroupDetails`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.18.3 - 2023-02-02
 - Add `PermissionTypes.CanSeeUserDetails`
 
 ## 1.18.2 - 2023-01-20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.2",
+  "version": "1.18.2-fb-userProfile.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.2",
+      "version": "1.18.2-fb-userProfile.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.2-fb-userProfile.0",
+  "version": "1.18.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.2-fb-userProfile.0",
+      "version": "1.18.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.2",
+  "version": "1.18.2-fb-userProfile.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.2-fb-userProfile.0",
+  "version": "1.18.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/constants.ts
+++ b/src/labkey/security/constants.ts
@@ -48,6 +48,7 @@ export enum PermissionTypes {
     ApplicationAdmin = 'org.labkey.api.security.permissions.ApplicationAdminPermission',
     CanSeeAuditLog = 'org.labkey.api.audit.permissions.CanSeeAuditLogPermission',
     CanSeeGroupDetails = 'org.labkey.api.security.permissions.SeeGroupDetailsPermission',
+    CanSeeUserDetails = 'org.labkey.api.security.permissions.SeeUserDetailsPermission',
     Delete = 'org.labkey.api.security.permissions.DeletePermission',
     DesignAssay = 'org.labkey.api.assay.security.DesignAssayPermission',
     DesignDataClass = 'org.labkey.api.security.permissions.DesignDataClassPermission',


### PR DESCRIPTION
#### Rationale
Currently in our apps, if a user clicks on a user display name in a grid, details page, timeline event, etc. they are taken to the #/q view context to view the details of that user (if they have "can view user details" permissions). This takes the user out of the context they were in and sometimes results in a mostly empty page (for users with only read perm, for examples). This story changes that so that we render user display names as clickable links, if current user has perm to see user details, that will open a modal with the user information without any page navigation.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1092

#### Changes
- Add CanSeeUserDetails permission
