### PR TITLE
ContainerFilters: AllInProject/AllInProjectPlusShared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.18.5 - 2023-02-24
+- Add the `AllInProject` and `AllInProjectPlusShared` container filter types supported starting in v23.03.
+
 ## 1.18.4 - 2023-02-23
 - Add `PermissionTypes.SampleWorkflowDelete`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.4",
+  "version": "1.18.4-fb-product-all-folders.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.4",
+      "version": "1.18.4-fb-product-all-folders.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.4-fb-product-all-folders.0",
+  "version": "1.18.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.4-fb-product-all-folders.0",
+      "version": "1.18.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.4",
+  "version": "1.18.4-fb-product-all-folders.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.4-fb-product-all-folders.0",
+  "version": "1.18.5",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Utils.spec.ts
+++ b/src/labkey/query/Utils.spec.ts
@@ -20,6 +20,8 @@ describe('ContainerFilter', () => {
     it('should be a case-sensitive string-based enum', () => {
         // The "value" of the enumeration is expected to bind to Java classes which is case-sensitive
         expect(ContainerFilter.allFolders).toEqual('AllFolders');
+        expect(ContainerFilter.allInProject).toEqual('AllInProject');
+        expect(ContainerFilter.allInProjectPlusShared).toEqual('AllInProjectPlusShared');
         expect(ContainerFilter.current).toEqual('Current');
         expect(ContainerFilter.currentAndFirstChildren).toEqual('CurrentAndFirstChildren');
         expect(ContainerFilter.currentAndParents).toEqual('CurrentAndParents');
@@ -30,7 +32,7 @@ describe('ContainerFilter', () => {
 
         // All "values" of the ContainerFilter enum should be covered here -- if it has changed
         // this test will fail and the test should be updated accordingly.
-        expect(Object.keys(ContainerFilter).length).toEqual(8);
+        expect(Object.keys(ContainerFilter).length).toEqual(10);
     });
     it('should be equivalent to "containerFilter"', () => {
         // Backwards compatibility support

--- a/src/labkey/query/Utils.ts
+++ b/src/labkey/query/Utils.ts
@@ -40,6 +40,12 @@ export enum ContainerFilter {
     /** Include all folders for which the user has read permission. */
     allFolders = 'AllFolders',
 
+    /** Include the current project and all folders in the current project. */
+    allInProject = 'AllInProject',
+
+    /** Include the current project, Shared project, and all folders in the current project. */
+    allInProjectPlusShared = 'AllInProjectPlusShared',
+
     /** Include the current folder only. */
     current = 'Current',
 


### PR DESCRIPTION
#### Rationale
Add new `Query.ContainerFilter` declarations for `AllInProject` and `AllInProjectPlusShared` container filter types introduced in v23.03 of LKS. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/145
- https://github.com/LabKey/labkey-ui-components/pull/1114
- https://github.com/LabKey/labkey-ui-premium/pull/47
- https://github.com/LabKey/biologics/pull/1942
- https://github.com/LabKey/sampleManagement/pull/1617
- https://github.com/LabKey/inventory/pull/742
- https://github.com/LabKey/recipe/pull/81
- https://github.com/LabKey/platform/pull/4129

#### Changes
* Add the `AllInProject` and `AllInProjectPlusShared` container filter types supported starting in v23.03.
