### PR TITLE
Issue 46469: Encapsulate run properties in LineageNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.6 - 2023-02-28
+* Update `LineageItemBase` to optionally include `comment?: string`.
+* Update `LineageNodeBase` to optionally include `protocol?: LineageItemBase`.
+
 ## 1.18.5 - 2023-02-24
 - Add the `AllInProject` and `AllInProjectPlusShared` container filter types supported starting in v23.03.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.5-fb-lineage-46469.0",
+  "version": "1.18.5-fb-lineage-46469.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.5-fb-lineage-46469.0",
+      "version": "1.18.5-fb-lineage-46469.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.5",
+  "version": "1.18.5-fb-lineage-46469.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.5",
+      "version": "1.18.5-fb-lineage-46469.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.5-fb-lineage-46469.1",
+  "version": "1.18.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.18.5-fb-lineage-46469.1",
+      "version": "1.18.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.5-fb-lineage-46469.1",
+  "version": "1.18.6",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.5-fb-lineage-46469.0",
+  "version": "1.18.5-fb-lineage-46469.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.18.5",
+  "version": "1.18.5-fb-lineage-46469.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -179,6 +179,7 @@ export interface LineagePKFilter {
 }
 
 export interface LineageItemBase {
+    comment?: string;
     container: string;
     cpasType?: string;
     created: string;
@@ -221,11 +222,12 @@ export interface LineageNodeBase {
     parents: LineageEdge[];
     pipelinePath: string;
     properties: any;
+    protocol?: LineageItemBase;
     steps?: LineageRunStep[];
 }
 
 /** The shape of a LineageNode is determined by the options specified on the lineage API. */
-export type LineageNode = LineageItemBase & LineageIOConfig & LineageNodeBase & Partial<LineageRunStepBase>;
+export type LineageNode = LineageItemBase & LineageIOConfig & LineageNodeBase;
 
 export interface LineageResponse {
     /** Object containing all lineage nodes in this lineage result. Keyed by node LSID. */

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -224,7 +224,8 @@ export interface LineageNodeBase {
     steps?: LineageRunStep[];
 }
 
-export type LineageNode = LineageItemBase & LineageIOConfig & LineageNodeBase;
+/** The shape of a LineageNode is determined by the options specified on the lineage API. */
+export type LineageNode = LineageItemBase & LineageIOConfig & LineageNodeBase & Partial<LineageRunStepBase>;
 
 export interface LineageResponse {
     /** Object containing all lineage nodes in this lineage result. Keyed by node LSID. */


### PR DESCRIPTION
#### Rationale
This addresses [Issue 46469](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46469) by updating the typings of `LineageNode` to optionally include `comments` and `protocol`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/148
- https://github.com/LabKey/labkey-ui-components/pull/1124
- https://github.com/LabKey/labkey-ui-premium/pull/55
- https://github.com/LabKey/biologics/pull/1962
- https://github.com/LabKey/sampleManagement/pull/1636
- https://github.com/LabKey/inventory/pull/751
- https://github.com/LabKey/platform/pull/4157

#### Changes
* Update `LineageItemBase` to optionally include `comment?: string`.
* Update `LineageNodeBase` to optionally include `protocol?: LineageItemBase`.
