### PR TITLE
Performance Evaluation for Data at Scale - Improve Insert/UpdateRows calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.19.1 - 2023-04-XX
+- Add skipReselectRows parameter to IQueryRequestOptions
+
 ## 1.19.0 - 2023-03-22
 - Package updates
 - Extract jest configuration out of `package.json` and into `jest.config.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.1-fb-skipQueryReselect.1",
+  "version": "1.19.1-fb-skipQueryReselect.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.19.1-fb-skipQueryReselect.1",
+      "version": "1.19.1-fb-skipQueryReselect.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.2-fb-skipQueryReselect.1",
+  "version": "1.19.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.19.2-fb-skipQueryReselect.1",
+      "version": "1.19.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.1",
+  "version": "1.19.2-fb-skipQueryReselect.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.19.1",
+      "version": "1.19.2-fb-skipQueryReselect.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",
@@ -11046,19 +11046,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
       "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
       "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/serve": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
       "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -11098,13 +11101,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -11137,7 +11142,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -12061,7 +12067,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -13753,7 +13760,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -16168,7 +16176,8 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
       "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.0",
+  "version": "1.19.1-fb-skipQueryReselect.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.19.0",
+      "version": "1.19.1-fb-skipQueryReselect.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",
@@ -11046,19 +11046,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
       "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
       "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/serve": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
       "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -11098,13 +11101,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -11137,7 +11142,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -12061,7 +12067,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -13753,7 +13760,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -16168,7 +16176,8 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
       "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.0",
+  "version": "1.19.1-fb-skipQueryReselect.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.2-fb-skipQueryReselect.1",
+  "version": "1.19.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.1-fb-skipQueryReselect.1",
+  "version": "1.19.1-fb-skipQueryReselect.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -62,7 +62,7 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
      */
     schemaName: string;
     /**
-     * Whether qus.getRows should be called to return the update/insert results.
+     * Whether the full detailed response for the update/insert rows can be skipped.
      * Defaults to false.
      */
     skipReselectRows?: boolean;

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -377,6 +377,7 @@ function sendRequest(options: SendRequestOptions, supportsFiles?: boolean): XMLH
         extraContext: options.extraContext,
         auditBehavior: options.auditBehavior,
         auditUserComment: options.auditUserComment,
+        skipReselectRows: options.skipReselectRows,
     };
 
     const form = bindFormData(jsonData, options, supportsFiles);

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -62,6 +62,11 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
      */
     schemaName: string;
     /**
+     * Whether qus.getRows should be called to return the update/insert results.
+     * Defaults to false.
+     */
+    skipReselectRows?: boolean;
+    /**
      * The maximum number of milliseconds to allow for this operation before
      * generating a timeout error (defaults to 30000).
      */


### PR DESCRIPTION
#### Rationale
selectRows is called immediately after insert/update to select the full results as response. Most of the time, the full results in response is not needed. A skipReselectRows parameter is added to allow selectRows and updateRows to skip the reselect.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/151
* https://github.com/LabKey/labkey-ui-components/pull/1175
* https://github.com/LabKey/labkey-ui-premium/pull/80
* https://github.com/LabKey/platform/pull/4312
* https://github.com/LabKey/inventory/pull/826
* https://github.com/LabKey/biologics/pull/2096
* https://github.com/LabKey/sampleManagement/pull/1777

#### Changes
* Add skipReselectRows parameter to IQueryRequestOptions
