### PR TITLE
Issue 47509: Resolve sample names that are integers during assay data import 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - TBD
+## 1.19.1 - 2023-04-19
 - Add the `allowLookupByAlternateKey` param to the `Assay.importRun()` API
 
 ## 1.19.0 - 2023-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - TBD
+- Add the `allowLookupByAlternateKey` param to the `Assay.importRun()` API
+
 ## 1.19.0 - 2023-03-22
 - Package updates
 - Extract jest configuration out of `package.json` and into `jest.config.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.0",
+  "version": "1.19.0-fb-intSampleNameWithAssays47509.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.19.0",
+      "version": "1.19.0-fb-intSampleNameWithAssays47509.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.0-fb-intSampleNameWithAssays47509.0",
+  "version": "1.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.19.0-fb-intSampleNameWithAssays47509.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.0-fb-intSampleNameWithAssays47509.0",
+  "version": "1.19.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.19.0",
+  "version": "1.19.0-fb-intSampleNameWithAssays47509.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -23,6 +23,7 @@ declare let window: FormWindow;
 
 export interface IImportRunOptions {
     allowCrossRunFileInputs?: boolean;
+    allowLookupByAlternateKey?: boolean;
     assayId?: number | string;
     batchId?: number | string;
     batchProperties?: any;
@@ -107,6 +108,9 @@ export function importRun(options: IImportRunOptions): void {
     }
     if (options.workflowTask !== undefined) {
         formData.append('workflowTask', options.workflowTask.toString(10));
+    }
+    if (options.allowLookupByAlternateKey !== undefined) {
+        formData.append('allowLookupByAlternateKey', options.allowLookupByAlternateKey ? 'true' : 'false');
     }
 
     if (options.properties) {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47509

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4316

#### Changes
* Add the `allowLookupByAlternateKey` param to the `Assay.importRun()` API
