### PR TITLE
AssayDOM.importRun: support "plateMetadata" property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.22.0 - 2023-07-14
+- Support `plateMetadata` JSON property on `AssayDOM.importRun`.
+- Rename `IImportRunOptions` to `ImportRunOptions`.
+- Extend `RequestCallbackOptions` to streamline usage of common request options.
+- Factor out superfluous `FormWindow` type. TypeScript typings for DOM libraries have improved since initial implementation.
+
 ## 1.21.0 - 2023-05-23
 - Fixes the implementation of `List.create()` to support `keyName` and `keyType` as they were originally documented.
 - Deprecate `keyName` in favor of specifying `options.keyName` as specified on `Domain.create()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.21.0-fb-app-plates.0",
+  "version": "1.21.0-fb-app-plates.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.21.0-fb-app-plates.0",
+      "version": "1.21.0-fb-app-plates.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.21.0",
+  "version": "1.21.0-fb-app-plates.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.21.0",
+      "version": "1.21.0-fb-app-plates.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.21.0-fb-app-plates.1",
+  "version": "1.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.21.0-fb-app-plates.1",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.21.0-fb-app-plates.0",
+  "version": "1.21.0-fb-app-plates.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.21.0",
+  "version": "1.21.0-fb-app-plates.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.21.0-fb-app-plates.1",
+  "version": "1.22.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -32,6 +32,7 @@ export interface ImportRunOptions extends RequestCallbackOptions {
     jobDescription?: string;
     jobNotificationProvider?: string;
     name?: string;
+    plateMetadata?: any;
     properties?: any;
     reRunId?: number | string;
     runFilePath?: string;
@@ -139,6 +140,10 @@ export function importRun(options: ImportRunOptions): XMLHttpRequest {
         for (let i = 0; i < files.length; i++) {
             formData.append('file' + i, files[i]);
         }
+    }
+
+    if (options.plateMetadata) {
+        formData.append('plateMetadata', JSON.stringify(options.plateMetadata));
     }
 
     return request({

--- a/src/labkey/dom/Query.ts
+++ b/src/labkey/dom/Query.ts
@@ -19,10 +19,7 @@ import { getCallbackWrapper, getOnFailure, getOnSuccess, merge } from '../Utils'
 import { appendFilterParams } from '../filter/Filter';
 import { ContainerFilter } from '../query/Utils';
 
-import { FormWindow } from './constants';
 import { postToAction } from './Utils';
-
-declare let window: FormWindow;
 
 export interface IExportSqlOptions {
     containerFilter?: ContainerFilter;
@@ -120,7 +117,7 @@ export interface IImportDataOptions {
 }
 
 export function importData(options: IImportDataOptions): XMLHttpRequest {
-    if (!window.FormData) {
+    if (!FormData) {
         throw new Error('modern browser required');
     }
 

--- a/src/labkey/dom/constants.ts
+++ b/src/labkey/dom/constants.ts
@@ -15,11 +15,6 @@
  */
 import { LabKey } from '../constants';
 
-export interface FormWindow extends Window {
-    File: any;
-    FormData: any;
-}
-
 export interface LabKeyDOM extends LabKey {
     $: any;
     requiresExt4ClientAPI: Function;


### PR DESCRIPTION
#### Rationale
Adds support for `plateMetadata` property on `AssayDOM.importRun`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/155
* https://github.com/LabKey/labkey-ui-components/pull/1234
* https://github.com/LabKey/labkey-ui-premium/pull/137
* https://github.com/LabKey/platform/pull/4583
* https://github.com/LabKey/commonAssays/pull/624
* https://github.com/LabKey/biologics/pull/2237
* https://github.com/LabKey/sampleManagement/pull/1966
* https://github.com/LabKey/inventory/pull/923

#### Changes
* Support `plateMetadata` JSON property on `AssayDOM.importRun`.
* Rename `IImportRunOptions` to `ImportRunOptions`.
* Extend `RequestCallbackOptions` to streamline usage of common request options.
* Factor out superfluous `FormWindow` type. TypeScript typings for DOM libraries have improved since initial implementation.
