### PR TITLE
Query.getQueryDetails: update options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.24.2 - 2023-09-11
+* Update typings for `fields`, `fk`, and `viewName` properties of `Query.getQueryDetails`
+* Add support for `method` to `Query.getQueryDetails`
+
 ## 1.24.1 - 2023-08-30
 - Add setEntitySequence, getEntitySequence methods to Experiment
 - Remove setGenId, getGenId from Experiment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.1-fb-plate-editing.0",
+  "version": "1.24.1-fb-plate-editing.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.24.1-fb-plate-editing.0",
+      "version": "1.24.1-fb-plate-editing.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.1-fb-plate-editing.1",
+  "version": "1.24.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.24.1-fb-plate-editing.1",
+      "version": "1.24.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.1",
+  "version": "1.24.1-fb-plate-editing.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.24.1",
+      "version": "1.24.1-fb-plate-editing.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.1-fb-plate-editing.0",
+  "version": "1.24.1-fb-plate-editing.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.1",
+  "version": "1.24.1-fb-plate-editing.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.1-fb-plate-editing.1",
+  "version": "1.24.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -599,10 +599,10 @@ export function saveRuns(options: SaveRunsOptions): XMLHttpRequest {
 
 export interface EntitySequenceActionsOptions extends RequestCallbackOptions {
     containerPath?: string;
-    seqType: 'genId' | 'rootSampleCount' | 'sampleCount';
-    newValue?: number;
     kindName?: 'SampleSet' | 'DataClass';
+    newValue?: number;
     rowId?: number;
+    seqType: 'genId' | 'rootSampleCount' | 'sampleCount';
 }
 
 /**

--- a/src/labkey/Utils.spec.ts
+++ b/src/labkey/Utils.spec.ts
@@ -340,7 +340,9 @@ describe('wafEncode', () => {
     });
     it('encodes string values', () => {
         expect(Utils.wafEncode('hello')).toEqual(`${prefix}aGVsbG8=`);
-        expect(Utils.wafEncode('DELETE TABLE some.table;')).toEqual(`${prefix}REVMRVRFJTIwVEFCTEUlMjBzb21lLnRhYmxlJTNC`);
+        expect(Utils.wafEncode('DELETE TABLE some.table;')).toEqual(
+            `${prefix}REVMRVRFJTIwVEFCTEUlMjBzb21lLnRhYmxlJTNC`
+        );
     });
     it('ignores other value types', () => {
         expect(Utils.wafEncode(1 as any)).toEqual(1);

--- a/src/labkey/Utils.ts
+++ b/src/labkey/Utils.ts
@@ -361,7 +361,7 @@ export function encodeHtml(html: string, retainEmptyValueTypes?: boolean): strin
         .replace(/'/g, '&#39;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/\\/g, "&#92");
+        .replace(/\\/g, '&#92');
 }
 
 export function escapeRe(s: string): string {

--- a/src/labkey/filter/Types.ts
+++ b/src/labkey/filter/Types.ts
@@ -119,14 +119,7 @@ const NOT_EQUAL = registerFilterType(
     '<>'
 );
 /** Finds rows where the column value is not in any of the supplied filter values. Use semicolons or new lines to separate entries.*/
-const NOT_IN = registerFilterType(
-    'Does Not Equal Any Of',
-    null,
-    'notin',
-    true,
-    ';',
-    'Does Not Equal Any Of'
-);
+const NOT_IN = registerFilterType('Does Not Equal Any Of', null, 'notin', true, ';', 'Does Not Equal Any Of');
 const NEQ_OR_NULL = registerFilterType(NOT_EQUAL.getDisplayText(), NOT_EQUAL.getDisplaySymbol(), 'neqornull', true);
 
 // Mutable due to "_define"
@@ -233,14 +226,7 @@ export const Types: Record<string, IFilterType> = {
     CONTAINS: registerFilterType('Contains', null, 'contains', true),
     DOES_NOT_CONTAIN: registerFilterType('Does Not Contain', null, 'doesnotcontain', true),
 
-    CONTAINS_ONE_OF: registerFilterType(
-        'Contains One Of',
-        null,
-        'containsoneof',
-        true,
-        ';',
-        'Contains One Of'
-    ),
+    CONTAINS_ONE_OF: registerFilterType('Contains One Of', null, 'containsoneof', true, ';', 'Contains One Of'),
     CONTAINS_NONE_OF: registerFilterType(
         'Does Not Contain Any Of',
         null,

--- a/src/labkey/query/GetQueryDetails.ts
+++ b/src/labkey/query/GetQueryDetails.ts
@@ -18,6 +18,7 @@ import { buildURL } from '../ActionURL';
 import { getCallbackWrapper, getOnFailure, getOnSuccess, RequestCallbackOptions } from '../Utils';
 import { Container } from '../constants';
 
+import { getMethod } from './Utils';
 import { QueryColumn } from './types';
 
 export interface QueryImportTemplate {
@@ -119,6 +120,8 @@ export interface GetQueryDetailsOptions extends RequestCallbackOptions<QueryDeta
     includeTriggers?: boolean;
     /** Initialize the view based on the default view iff the view doesn't yet exist. */
     initializeMissingView?: boolean;
+    /** Specify the HTTP method to use when making the request. Defaults to GET. */
+    method?: 'GET' | 'POST';
     /** The name of the query. */
     queryName: string;
     /** The name of the schema. */
@@ -170,6 +173,7 @@ export function getQueryDetails(options: GetQueryDetailsOptions): XMLHttpRequest
 
     return request({
         url: buildURL('query', 'getQueryDetails.api', options.containerPath),
+        method: getMethod(options.method),
         success: getCallbackWrapper(getOnSuccess(options), options.scope),
         failure: getCallbackWrapper(getOnFailure(options), options.scope, true),
         params,

--- a/src/labkey/query/GetQueryDetails.ts
+++ b/src/labkey/query/GetQueryDetails.ts
@@ -112,8 +112,9 @@ export interface GetQueryDetailsOptions extends RequestCallbackOptions<QueryDeta
      */
     containerPath?: string;
     /** A field key or Array of field keys to include in the metadata. */
-    fields?: any;
-    fk?: any;
+    fields?: string | string[];
+    /** When specified the response will only include columns from the specified foreign key query. */
+    fk?: string;
     /** Include trigger metadata in the response. */
     includeTriggers?: boolean;
     /** Initialize the view based on the default view iff the view doesn't yet exist. */
@@ -126,7 +127,7 @@ export interface GetQueryDetailsOptions extends RequestCallbackOptions<QueryDeta
      * A view name or Array of view names to include custom view details.
      * Use '*' to include all views for the query.
      */
-    viewName?: string;
+    viewName?: string | string[];
 }
 
 /**
@@ -159,7 +160,7 @@ export function getQueryDetails(options: GetQueryDetailsOptions): XMLHttpRequest
         params.fk = options.fk;
     }
 
-    if (options.initializeMissingView) {
+    if (options.initializeMissingView !== undefined) {
         params.initializeMissingView = options.initializeMissingView;
     }
 


### PR DESCRIPTION
#### Rationale
This updates the typings for `Query.getQueryDetails` options to align with what is supported by the endpoint.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/160
* https://github.com/LabKey/labkey-ui-components/pull/1280
* https://github.com/LabKey/labkey-ui-premium/pull/177
* https://github.com/LabKey/biologics/pull/2349
* https://github.com/LabKey/sampleManagement/pull/2072
* https://github.com/LabKey/inventory/pull/1004
* https://github.com/LabKey/platform/pull/4729

#### Changes
* Update typings for `fields`, `fk`, and `viewName`
* Add support for `method`
