### PR TITLE
Add ability to share non-default custom grid views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD - 2023-10-TBD
+## 1.25.0 - 2023-10-13
 - Add `PermissionTypes.EditSharedView`
 
 ## 1.24.2 - 2023-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD - 2023-10-TBD
+- Add `PermissionTypes.EditSharedView`
+
 ## 1.24.2 - 2023-09-11
 * Update typings for `fields`, `fk`, and `viewName` properties of `Query.getQueryDetails`
 * Add support for `method` to `Query.getQueryDetails`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.3-sharedViews.0",
+  "version": "1.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.24.3-sharedViews.0",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.2",
+  "version": "1.24.3-sharedViews.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.24.2",
+      "version": "1.24.3-sharedViews.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.3-sharedViews.0",
+  "version": "1.25.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.24.2",
+  "version": "1.24.3-sharedViews.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/constants.ts
+++ b/src/labkey/security/constants.ts
@@ -55,6 +55,7 @@ export enum PermissionTypes {
     DesignList = 'org.labkey.api.lists.permissions.DesignListPermission',
     DesignSampleSet = 'org.labkey.api.security.permissions.DesignSampleTypePermission',
     DesignStorage = 'org.labkey.api.inventory.security.StorageDesignPermission',
+    EditSharedView = 'org.labkey.api.security.permissions.EditSharedViewPermission',
     EditStorageData = 'org.labkey.api.inventory.security.StorageDataUpdatePermission',
     Insert = 'org.labkey.api.security.permissions.InsertPermission',
     ManagePicklists = 'org.labkey.api.lists.permissions.ManagePicklistsPermission',


### PR DESCRIPTION
#### Rationale
See related PR in labkey-ui-components

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1313

#### Changes
* Add constant for `EditSharedViewPermission` class
