### PR TITLE
Assay.getAssays, deprecate alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.26.0 - 2023-10-18
+- Expose `Assay.getAssays` and update documentation.
+- Deprecate `Assay.getById`, `Assay.getByName`, and `Assay.getByType` in favor of `Assay.getAssays`.
+- Add typings for supported parameters of the `assay-assayList.api` endpoint.
+
 ## 1.25.0 - 2023-10-13
 - Add `PermissionTypes.EditSharedView`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.0",
+  "version": "1.25.1-fb-plate-polish.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.25.0",
+      "version": "1.25.1-fb-plate-polish.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-fb-plate-polish.0",
+  "version": "1.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.25.1-fb-plate-polish.0",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.0",
+  "version": "1.25.1-fb-plate-polish.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-fb-plate-polish.0",
+  "version": "1.26.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Assay.spec.ts
+++ b/src/labkey/Assay.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as Ajax from './Ajax';
-import { getAll, getById, getByName, getByType } from './Assay';
+import { getAll, getAssays, getById, getByName, getByType } from './Assay';
 
 describe('assayList.api requests', () => {
     const success = jest.fn();
@@ -98,6 +98,26 @@ describe('assayList.api requests', () => {
             expect.objectContaining({
                 jsonData: { type: assayType },
                 url: '/assay/my/special/folder/assayList.api',
+            })
+        );
+    });
+
+    test('getAssays move parameters', () => {
+        // Arrange
+        const id = 42;
+        const name = 'Jackie';
+        const plateEnabled = true;
+        const status = 'Archived';
+        const type = 'Player';
+
+        // Act
+        getAssays({ failure, id, name, plateEnabled, status, success, type });
+
+        // Assert
+        expect(requestSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                jsonData: { id, name, plateEnabled, status, type },
+                url: '/assay/assayList.api',
             })
         );
     });

--- a/src/labkey/Assay.ts
+++ b/src/labkey/Assay.ts
@@ -49,7 +49,7 @@ function applyArguments(args: IArguments, options: GetAssaysOptions, parameter?:
     return _options;
 }
 
-type GetAssaysParameters = {
+export type GetAssaysParameters = {
     /** Applies a filter to match against only assay designs with the provided "id". */
     id?: number;
     /** Applies a filter to match against only assay designs with the provided "name". */

--- a/src/labkey/Assay.ts
+++ b/src/labkey/Assay.ts
@@ -123,23 +123,8 @@ export interface AssayDesign {
     type: string;
 }
 
-// TODO: Document
-export function getAssays(options: GetAssaysOptions): XMLHttpRequest {
-    moveParameters(options, 'id', 'name', 'plateEnabled', 'status', 'type');
-
-    return request({
-        url: buildURL('assay', 'assayList.api', options.containerPath),
-        method: 'POST',
-        jsonData: options.parameters,
-        success: getCallbackWrapper(getOnSuccess(options), options.scope, false, data => data.definitions),
-        failure: getCallbackWrapper(getOnFailure(options), options.scope, true),
-        scope: options.scope || this,
-    });
-}
-
 /**
- * @deprecated Use {@link getAssays} instead.
- * Gets all assays
+ * Gets assay designs available in a folder. Optionally, filter the results based on criteria.
  * #### Examples
  *
  * ```
@@ -166,9 +151,28 @@ export function getAssays(options: GetAssaysOptions): XMLHttpRequest {
  *  alert('An error occurred retrieving data.');
  * }
  *
- * LABKEY.Assay.getAll({success: successHandler, failure: errorHandler});
+ * // Get all assay design of type "General"
+ * LABKEY.Assay.getAssays({ success: successHandler, failure: errorHandler, type: 'General' });
  * ```
  * @param options
+ * @see {@link AssayDesign}
+ */
+export function getAssays(options: GetAssaysOptions): XMLHttpRequest {
+    moveParameters(options, 'id', 'name', 'plateEnabled', 'status', 'type');
+
+    return request({
+        url: buildURL('assay', 'assayList.api', options.containerPath),
+        method: 'POST',
+        jsonData: options.parameters,
+        success: getCallbackWrapper(getOnSuccess(options), options.scope, false, data => data.definitions),
+        failure: getCallbackWrapper(getOnFailure(options), options.scope, true),
+        scope: options.scope || this,
+    });
+}
+
+/**
+ * @deprecated Use {@link getAssays} instead.
+ * Gets all assay designs.
  * @see {@link AssayDesign}
  */
 export function getAll(options: GetAssaysOptions): XMLHttpRequest {
@@ -182,7 +186,7 @@ export interface GetByIdOptions extends GetAssaysOptions {
 
 /**
  * @deprecated Use {@link getAssays} instead and specify the `id` option.
- * Gets an assay by its ID.
+ * Gets an assay design by its ID.
  * @see {@link AssayDesign}
  */
 export function getById(options: GetByIdOptions): XMLHttpRequest {
@@ -196,7 +200,7 @@ export interface GetByNameOptions extends GetAssaysOptions {
 
 /**
  * @deprecated Use {@link getAssays} instead and specify the `name` option.
- * Gets an assay by name.
+ * Gets an assay design by name.
  * @param options
  * @see {@link AssayDesign}
  */
@@ -211,7 +215,7 @@ export interface GetByTypeOptions extends GetAssaysOptions {
 
 /**
  * @deprecated Use {@link getAssays} instead and specify the `type` option.
- * Gets an assay by type.
+ * Gets an assay design by type.
  * @param options
  * @see {@link AssayDesign}
  */
@@ -426,8 +430,9 @@ function moveParameters(config: any, ...params: string[]): void {
         config.parameters = {};
     }
 
-    for (const param in params) {
-        if (config[param]) {
+    for (let i = 0; i < params.length; i++) {
+        const param = params[i];
+        if (config.hasOwnProperty(param)) {
             config.parameters[param] = config[param];
             delete config[param];
         }


### PR DESCRIPTION
#### Rationale
Exposes `Assay.getAssays` and deprecates single-filter constraint related alternatives like `Assay.getById`, `Assay.getByType`, etc.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/162
* https://github.com/LabKey/labkey-ui-components/pull/1314
* https://github.com/LabKey/labkey-ui-premium/pull/219
* https://github.com/LabKey/platform/pull/4820
* https://github.com/LabKey/biologics/pull/2444
* https://github.com/LabKey/sampleManagement/pull/2165
* https://github.com/LabKey/inventory/pull/1059

#### Changes
* Expose `Assay.getAssays` and update documentation.
* Deprecate `Assay.getById`, `Assay.getByName`, and `Assay.getByType` in favor of `Assay.getAssays`.
* Add typings for supported parameters of the `assay-assayList.api` endpoint.
