### PR TITLE
Update parsing of Content-Disposition header to account for possible encoding prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### TBD - 2023-TBC
+- Update parsing for Content-Disposition header
+
 ## 1.25.0 - 2023-10-13
 - Add `PermissionTypes.EditSharedView`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### TBD - 2023-TBC
+### 1.26.1 - 2023-10-18
 - Update parsing for Content-Disposition header
 
 ## 1.26.0 - 2023-10-18

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.0",
+  "version": "1.25.1-rfc-5987.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.25.0",
+      "version": "1.25.1-rfc-5987.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.26.1-rfc-5987.4",
+  "version": "1.26.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.26.1-rfc-5987.4",
+      "version": "1.26.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-rfc-5987.1",
+  "version": "1.25.1-rfc-5987.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.25.1-rfc-5987.1",
+      "version": "1.25.1-rfc-5987.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-rfc-5987.2",
+  "version": "1.25.1-rfc-5987.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.25.1-rfc-5987.2",
+      "version": "1.25.1-rfc-5987.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-rfc-5987.3",
+  "version": "1.26.1-rfc-5987.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.25.1-rfc-5987.3",
+      "version": "1.26.1-rfc-5987.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-rfc-5987.0",
+  "version": "1.25.1-rfc-5987.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.25.1-rfc-5987.0",
+      "version": "1.25.1-rfc-5987.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.26.1-rfc-5987.3",
+  "version": "1.26.1-rfc-5987.4",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-rfc-5987.0",
+  "version": "1.25.1-rfc-5987.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.26.1-rfc-5987.4",
+  "version": "1.26.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-rfc-5987.2",
+  "version": "1.25.1-rfc-5987.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.0",
+  "version": "1.25.1-rfc-5987.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.25.1-rfc-5987.1",
+  "version": "1.25.1-rfc-5987.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -252,11 +252,20 @@ function downloadFile(xhr: XMLHttpRequest, config: any): void {
         // parse the filename out of the Content-Disposition header. Example:
         //   Content-Disposition: attachment; filename=data.xlsx
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+        // also
+        //   Content-Disposition: attachment; filename*=UTF-8''filename.xlsx
         const disposition = xhr.getResponseHeader('Content-Disposition');
         if (disposition && disposition.indexOf('attachment') !== -1) {
-            const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(disposition);
-            if (matches != null && matches[1]) {
-                filename = matches[1].replace(/['"]/g, '');
+            // const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(disposition);
+            const matches = /filename\*?=([^']*'')?(['"].*?['"]|[^;\n]*)/.exec(disposition);
+            if (matches) {
+                if (matches.length > 2) {
+                    var encoding = matches[1];
+                    filename = matches[2];
+                } else if (matches[1]) {
+                    filename = matches[1];
+                }
+                filename = filename.replace(/['"]/g, '');
             }
         }
     }

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -257,13 +257,8 @@ function downloadFile(xhr: XMLHttpRequest, config: any): void {
         const disposition = xhr.getResponseHeader('Content-Disposition');
         if (disposition && disposition.indexOf('attachment') !== -1) {
             const matches = /filename\*?=([^']*'')?(['"].*?['"]|[^;\n]*)/.exec(disposition);
-            if (matches) {
-                if (matches.length > 2) {
-                    filename = matches[2];
-                } else if (matches[1]) {
-                    filename = matches[1];
-                }
-                filename = decodeURI(filename.replace(/['"]/g, ''));
+            if (matches && matches[2]) {
+                filename = decodeURI(matches[2].replace(/['"]/g, ''));
             }
         }
     }

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -249,11 +249,14 @@ function downloadFile(xhr: XMLHttpRequest, config: any): void {
     if (typeof config.downloadFile === 'string') {
         filename = config.downloadFile;
     } else {
-        // parse the filename out of the Content-Disposition header. Example:
-        //   Content-Disposition: attachment; filename=data.xlsx
+        // parse the filename out of the Content-Disposition header.
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
-        // also
+        // Examples:
+        //   Content-Disposition: attachment; filename=data.xlsx
         //   Content-Disposition: attachment; filename*=UTF-8''filename.xlsx
+        //   Content-Disposition: attachment: filename=data.csv; filename*=UTF-8''filename.csv
+        //   Content-Disposition: attachment: filename*=UTF-8''data.csv; filename=filename.csv
+        // The pattern below will match the first filename provided (so, data.csv in the last two examples)
         const disposition = xhr.getResponseHeader('Content-Disposition');
         if (disposition && disposition.indexOf('attachment') !== -1) {
             const matches = /filename\*?=([^']*'')?(['"].*?['"]|[^;\n]*)/.exec(disposition);

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -256,7 +256,6 @@ function downloadFile(xhr: XMLHttpRequest, config: any): void {
         //   Content-Disposition: attachment; filename*=UTF-8''filename.xlsx
         const disposition = xhr.getResponseHeader('Content-Disposition');
         if (disposition && disposition.indexOf('attachment') !== -1) {
-            // const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(disposition);
             const matches = /filename\*?=([^']*'')?(['"].*?['"]|[^;\n]*)/.exec(disposition);
             if (matches) {
                 if (matches.length > 2) {

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -260,12 +260,11 @@ function downloadFile(xhr: XMLHttpRequest, config: any): void {
             const matches = /filename\*?=([^']*'')?(['"].*?['"]|[^;\n]*)/.exec(disposition);
             if (matches) {
                 if (matches.length > 2) {
-                    var encoding = matches[1];
                     filename = matches[2];
                 } else if (matches[1]) {
                     filename = matches[1];
                 }
-                filename = filename.replace(/['"]/g, '');
+                filename = decodeURI(filename.replace(/['"]/g, ''));
             }
         }
     }


### PR DESCRIPTION
#### Rationale
[Issue 48855](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48855) - We need to properly encode the filename in the Content-Disposition according to the standard, which means we need to update our parsing of said header. Without changes here, the file names that include UTF-8 characters look something like this: UTF-8%D0%92uffy%20%D0%A1oat_2023-10-16_08-08-20.xlsx

#### Related Pull Requests

- https://github.com/LabKey/platform/pull/4824
- https://github.com/LabKey/labkey-ui-components/pull/1319
- https://github.com/LabKey/labkey-ui-premium/pull/224
- https://github.com/LabKey/inventory/pull/1063
- https://github.com/LabKey/sampleManagement/pull/2174
- https://github.com/LabKey/biologics/pull/2452


#### Changes
* Update the pattern matching in downloadFile to properly strip off the encoding prefix and URI decode the rest of the name.
