### PR TITLE
Fix Utils.encodeHtml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.27.1 - 2023-11-9
+- Fix `Utils.encodeHtml` by adding necessary semicolon
+
 ### 1.27.0 - 2023-10-18
 - `Security.getUsersWithPermissions()`: Add includeInactive 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.27.1-fb-semicolon.0",
+  "version": "1.27.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.27.1-fb-semicolon.0",
+      "version": "1.27.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.27.0",
+  "version": "1.27.1-fb-semicolon.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.27.0",
+      "version": "1.27.1-fb-semicolon.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.27.1-fb-semicolon.0",
+  "version": "1.27.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.27.0",
+  "version": "1.27.1-fb-semicolon.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Utils.ts
+++ b/src/labkey/Utils.ts
@@ -361,7 +361,7 @@ export function encodeHtml(html: string, retainEmptyValueTypes?: boolean): strin
         .replace(/'/g, '&#39;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/\\/g, '&#92');
+        .replace(/\\/g, '&#92;');
 }
 
 export function escapeRe(s: string): string {


### PR DESCRIPTION
#### Rationale
Fix `Utils.encodeHtml` by fixing the replacement to include a `;`.

**Note:** It's intentional this is against the `develop` branch as this package does not maintain LKS branches (e.g. `release23.11-SNAPSHOT`).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4938

#### Changes
* Add `;`