### PR TITLE
Add auditUserComment to options for importing assay data and runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### TBD - 2024-TBD
+### 1.30.0 - 2024-03-11
 - Update `IImportDataOptions` and `ImportRunOptions` to include optional `auditUserComment` 
 
 ### 1.29.0 - 2024-01-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### TBD - 2024-TBD
+- Update `IImportDataOptions` to include optional `auditUserComment` 
+
 ### 1.29.0 - 2024-01-31
 - Add Container.formats.timeFormat
 - Support filter 'time' JsonType

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### TBD - 2024-TBD
-- Update `IImportDataOptions` to include optional `auditUserComment` 
+- Update `IImportDataOptions` and `ImportRunOptions` to include optional `auditUserComment` 
 
 ### 1.29.0 - 2024-01-31
 - Add Container.formats.timeFormat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.29.0",
+  "version": "1.29.1-commentsForEdit.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.29.0",
+      "version": "1.29.1-commentsForEdit.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.29.1-commentsForEdit.0",
+  "version": "1.29.1-commentsForEdit.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.29.1-commentsForEdit.0",
+      "version": "1.29.1-commentsForEdit.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.29.1-commentsForEdit.1",
+  "version": "1.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.29.1-commentsForEdit.1",
+      "version": "1.30.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.29.1-commentsForEdit.1",
+  "version": "1.30.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.29.1-commentsForEdit.0",
+  "version": "1.29.1-commentsForEdit.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.29.0",
+  "version": "1.29.1-commentsForEdit.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -21,6 +21,7 @@ export interface ImportRunOptions extends RequestCallbackOptions {
     allowCrossRunFileInputs?: boolean;
     allowLookupByAlternateKey?: boolean;
     assayId?: number | string;
+    auditUserComment?: string;
     batchId?: number | string;
     batchProperties?: any;
     comment?: string;
@@ -105,6 +106,9 @@ export function importRun(options: ImportRunOptions): XMLHttpRequest {
     }
     if (options.allowLookupByAlternateKey !== undefined) {
         formData.append('allowLookupByAlternateKey', options.allowLookupByAlternateKey ? 'true' : 'false');
+    }
+    if (options.auditUserComment !== undefined) {
+        formData.append('auditUserComment', options.auditUserComment);
     }
 
     if (options.properties) {

--- a/src/labkey/dom/Query.ts
+++ b/src/labkey/dom/Query.ts
@@ -95,6 +95,7 @@ export function exportTables(options: IExportTablesOptions): void {
 }
 
 export interface IImportDataOptions {
+    auditUserComment?: string;
     containerPath?: string;
     failure?: Function;
     file?: File | Element | any;
@@ -156,6 +157,9 @@ export function importData(options: IImportDataOptions): XMLHttpRequest {
     }
     if (options.insertOption !== undefined) {
         form.append('insertOption', options.insertOption);
+    }
+    if (options.auditUserComment !== undefined) {
+        form.append('auditUserComment', options.auditUserComment);
     }
 
     if (options.file) {


### PR DESCRIPTION
#### Rationale
We have previously added the ability for users to provide comments on various types of data changes (deleting, moving, discarding, etc.). With this PR and its relatives we introduce the ability to provide comments for edits of data in various forms, including editing in bulk or in the grid, updating via a file, reimporting and assay run, and editing on a details page.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1434

#### Changes
* Update `IImportDataOptions` and `ImportRunOptions` to include optional `auditUserComment`
