### PR TITLE
Assay import support for results domain file fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### TBD
+### 1.34.0 - 2024-06-10
 - Add `resultsFiles` to ImportRunOptions and importRun() in Assay.ts
 
 ### 1.33.0 - 2024-03-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### TBD
+- Add `resultsFiles` to ImportRunOptions and importRun() in Assay.ts
+
 ### 1.33.0 - 2024-03-26
 - Package updates
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.33.0",
+  "version": "1.33.0-fb-assayResultsFiles.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.33.0",
+      "version": "1.33.0-fb-assayResultsFiles.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.33.0-fb-assayResultsFiles.2",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.33.0-fb-assayResultsFiles.2",
+      "version": "1.34.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.33.0-fb-assayResultsFiles.1",
+  "version": "1.33.0-fb-assayResultsFiles.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.33.0-fb-assayResultsFiles.1",
+      "version": "1.33.0-fb-assayResultsFiles.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.33.0-fb-assayResultsFiles.2",
+  "version": "1.34.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.33.0-fb-assayResultsFiles.1",
+  "version": "1.33.0-fb-assayResultsFiles.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.33.0",
+  "version": "1.33.0-fb-assayResultsFiles.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -36,7 +36,7 @@ export interface ImportRunOptions extends RequestCallbackOptions {
     plateMetadata?: any;
     properties?: any;
     reRunId?: number | string;
-    resultsFiles?: any[];
+    resultsFiles?: File[];
     runFilePath?: string;
     saveDataAsFile?: boolean;
     workflowTask?: number;

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -36,6 +36,7 @@ export interface ImportRunOptions extends RequestCallbackOptions {
     plateMetadata?: any;
     properties?: any;
     reRunId?: number | string;
+    resultsFiles?: any[];
     runFilePath?: string;
     saveDataAsFile?: boolean;
     workflowTask?: number;
@@ -143,6 +144,12 @@ export function importRun(options: ImportRunOptions): XMLHttpRequest {
         formData.append('file', files[0]);
         for (let i = 0; i < files.length; i++) {
             formData.append('file' + i, files[i]);
+        }
+    }
+
+    if (options.resultsFiles && options.resultsFiles.length > 0) {
+        for (let i = 0; i < options.resultsFiles.length; i++) {
+            formData.append('resultsFile', options.resultsFiles[i]);
         }
     }
 


### PR DESCRIPTION
#### Rationale
This story makes it easier to import an assay run to the app in the case where the assay results domain has File field types. Before this, you had to individually and manually add files to results after importing/creating the run. Now I can make the associations in bulk and upload the results files while importing a run through the app UI.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/176
- https://github.com/LabKey/labkey-ui-components/pull/1501
- https://github.com/LabKey/labkey-ui-premium/pull/420
- https://github.com/LabKey/platform/pull/5533
- https://github.com/LabKey/limsModules/pull/302
- https://github.com/LabKey/commonAssays/pull/763

#### Changes
- Add assay import run options for resultsFiles
