### PR TITLE
Issue 50533: furnish server's timezone in server context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.34.1 - 2024-06-18
+- Issue 50533: furnish server's timezone in server context
+
 ### 1.34.0 - 2024-06-10
 - Add `resultsFiles` to ImportRunOptions and importRun() in Assay.ts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.34.0",
+  "version": "1.34.1-fb-timezones.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.34.0",
+      "version": "1.34.1-fb-timezones.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.34.1-fb-timezones.0",
+  "version": "1.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.34.1-fb-timezones.0",
+      "version": "1.34.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.34.0",
+  "version": "1.34.1-fb-timezones.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.34.1-fb-timezones.0",
+  "version": "1.34.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -138,6 +138,7 @@ export type LabKey = {
     serverName: string;
     sharedContainer?: string;
     submit: boolean;
+    timezone: string;
     tours: any;
     unloadMessage: string;
     useMDYDateParsing?: boolean;


### PR DESCRIPTION
#### Rationale
In support of [Issue 50533](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50533) the server's timezone configuration is now provided in the page's server context.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/177
- https://github.com/LabKey/labkey-ui-components/pull/1517
- https://github.com/LabKey/labkey-ui-premium/pull/444
- https://github.com/LabKey/limsModules/pull/375
- https://github.com/LabKey/platform/pull/5596

#### Changes
- Update typings to include `timezone`.
