### PR TITLE
Issue 50628: RFC 6266 compliant parsing of "Content-Disposition"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### TBD
 - Deprecate and strongly discourage use of bitmask-based permission constants and functions 
 
+### 1.35.1 - 2024-09-12
+- Issue 50628: Switch our "Content-Disposition" header parsing to utilize the `@tinyhttp/content-disposition` package.
+
 ### 1.35.0 - 2024-07-24
 - Package updates
 

--- a/jest.babel.config.js
+++ b/jest.babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    env: {
+        test: {
+            plugins: ['@babel/plugin-transform-modules-commonjs'],
+        },
+    },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,11 @@
+// Run all tests with timezone set to UTC
+// https://stackoverflow.com/a/56482581
+process.env.TZ = 'UTC';
+
+// These are ES modules that we utilize that need to be transformed
+// by babel when being imported during a jest test.
+const esModules = ['@tinyhttp/content-disposition', 'sinon'].join('|');
+
 module.exports = {
     globals: {
         LABKEY: {
@@ -8,13 +16,16 @@ module.exports = {
         },
     },
     moduleFileExtensions: ['ts', 'js'],
-    moduleNameMapper: {
-        '^sinon$': require.resolve('sinon'),
-    },
     testEnvironment: 'jsdom',
     testResultsProcessor: 'jest-teamcity-reporter',
     testRegex: '(\\.(spec))\\.(ts)$',
     transform: {
+        '\\.js$': [
+            'babel-jest',
+            {
+                configFile: './jest.babel.config.js',
+            },
+        ],
         '^.+\\.ts$': [
             'ts-jest',
             {
@@ -23,4 +34,5 @@ module.exports = {
             },
         ],
     },
+    transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,9 @@ module.exports = {
         LABKEY: {
             contextPath: '',
             defaultHeaders: {
-                'X-LABKEY-CSRF': 'TEST_CSRF_TOKEN'
-            }
-        }
+                'X-LABKEY-CSRF': 'TEST_CSRF_TOKEN',
+            },
+        },
     },
     moduleFileExtensions: ['ts', 'js'],
     moduleNameMapper: {
@@ -20,7 +20,7 @@ module.exports = {
             {
                 // This increases test perf by a considerable margin
                 isolatedModules: true,
-            }
+            },
         ],
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.0",
+  "version": "1.35.1-fb-content-disp.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.0",
+      "version": "1.35.1-fb-content-disp.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.1-fb-content-disp.0",
+  "version": "1.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.1-fb-content-disp.0",
+      "version": "1.35.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",
+        "@babel/plugin-transform-modules-commonjs": "7.24.8",
         "@labkey/eslint-config-base": "0.0.15",
         "@tinyhttp/content-disposition": "2.2.1",
         "@types/jest": "29.5.12",
@@ -464,6 +465,23 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
+      "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.24.8",
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-simple-access": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@babel/core": "7.24.9",
         "@labkey/eslint-config-base": "0.0.15",
+        "@tinyhttp/content-disposition": "2.2.1",
         "@types/jest": "29.5.12",
         "@types/sinon": "17.0.3",
         "cross-env": "7.0.3",
@@ -1720,6 +1721,19 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "node_modules/@tinyhttp/content-disposition": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.1.tgz",
+      "integrity": "sha512-PQ5IWdOn7arScqTV+usIDJvwbanoAXtaopzgxjMS9y7TFwLSIelCblihRBEVIPIkIpsdhSJFH3RF+Daosyj+Aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/tinyhttp/tinyhttp?sponsor=1"
+      }
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.1-fb-content-disp.0",
+  "version": "1.35.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@babel/core": "7.24.9",
     "@labkey/eslint-config-base": "0.0.15",
+    "@tinyhttp/content-disposition": "2.2.1",
     "@types/jest": "29.5.12",
     "@types/sinon": "17.0.3",
     "cross-env": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.24.9",
+    "@babel/plugin-transform-modules-commonjs": "7.24.8",
     "@labkey/eslint-config-base": "0.0.15",
     "@tinyhttp/content-disposition": "2.2.1",
     "@types/jest": "29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.0",
+  "version": "1.35.1-fb-content-disp.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Ajax.spec.ts
+++ b/src/labkey/Ajax.spec.ts
@@ -18,7 +18,7 @@ import sinon from 'sinon';
 import * as Ajax from './Ajax';
 import { getFilenameFromContentDisposition } from './Ajax';
 
-function mockXHR() {
+function mockXHR(): void {
     let xhr: sinon.SinonFakeXMLHttpRequestStatic;
 
     afterEach(() => {
@@ -41,109 +41,129 @@ function request(options: Ajax.RequestOptions): FakeXMLHttpRequest {
     return Ajax.request(options) as FakeXMLHttpRequest;
 }
 
-describe('request', () => {
-    mockXHR();
+describe('Ajax', () => {
+    describe('request', () => {
+        mockXHR();
 
-    it('should require configuration', () => {
-        expect(() => {
-            (Ajax.request as any)();
-        }).toThrow('a URL is required to make a request');
-        expect(() => {
-            (Ajax.request as any)({});
-        }).toThrow('a URL is required to make a request');
+        it('should require configuration', () => {
+            expect(() => {
+                (Ajax.request as any)();
+            }).toThrow('a URL is required to make a request');
+            expect(() => {
+                (Ajax.request as any)({});
+            }).toThrow('a URL is required to make a request');
+        });
+        it('should make request with only url', () => {
+            expect(request({ url: '/users' }).url).toEqual('/users');
+        });
     });
-    it('should make request with only url', () => {
-        expect(request({ url: '/users' }).url).toEqual('/users');
-    });
-});
 
-describe('request headers', () => {
-    mockXHR();
+    describe('request headers', () => {
+        mockXHR();
 
-    const testCSRF = 'TEST_CSRF_TOKEN';
-    const contentTypeForm = 'application/x-www-form-urlencoded;charset=utf-8';
+        const testCSRF = 'TEST_CSRF_TOKEN';
+        const contentTypeForm = 'application/x-www-form-urlencoded;charset=utf-8';
 
-    it('should apply DEFAULT_HEADERS', () => {
-        const requestHeaders = request({ url: '/projects' }).requestHeaders;
+        it('should apply DEFAULT_HEADERS', () => {
+            const requestHeaders = request({ url: '/projects' }).requestHeaders;
 
-        expect(requestHeaders['Content-Type']).toEqual(contentTypeForm);
-        expect(requestHeaders['X-Requested-With']).toEqual('XMLHttpRequest');
-        expect(requestHeaders['X-LABKEY-CSRF']).toEqual(testCSRF);
-    });
-    it('should apply custom headers', () => {
-        const requestHeaders = request({
-            url: '/projects',
-            headers: {
-                foo: 'bar',
-            },
-        }).requestHeaders;
-
-        expect(requestHeaders['foo']).toEqual('bar');
-        expect(requestHeaders['X-LABKEY-CSRF']).toEqual(testCSRF); // it shouldn't lose other headers
-    });
-});
-
-describe('request method', () => {
-    mockXHR();
-
-    it('should default to GET', () => {
-        expect(request({ url: '/users' }).method).toEqual('GET');
-    });
-    it('should default to POST with data', () => {
-        expect(
-            request({
-                url: '/users',
-                jsonData: {
-                    userId: 123,
+            expect(requestHeaders['Content-Type']).toEqual(contentTypeForm);
+            expect(requestHeaders['X-Requested-With']).toEqual('XMLHttpRequest');
+            expect(requestHeaders['X-LABKEY-CSRF']).toEqual(testCSRF);
+        });
+        it('should apply custom headers', () => {
+            const requestHeaders = request({
+                url: '/projects',
+                headers: {
+                    foo: 'bar',
                 },
-            }).method
-        ).toEqual('POST');
-    });
-    it('should accept GET with data', () => {
-        expect(
-            request({
-                url: '/users',
-                method: 'GET',
-                jsonData: {
-                    userId: 123,
-                },
-            }).method
-        ).toEqual('GET');
-    });
-    it('should accept any method', () => {
-        expect(request({ url: '/users', method: 'DELETE' }).method).toEqual('DELETE');
-        expect(request({ url: '/users', method: 'PUT' }).method).toEqual('PUT');
-        expect(request({ url: '/users', method: 'BEEP' }).method).toEqual('BEEP');
-    });
-});
+            }).requestHeaders;
 
-describe('getFilenameFromContentDisposition', () => {
-    it('should not find a file if there is no attachment prefix', () => {
-        expect(getFilenameFromContentDisposition('other: filename=data.tsv')).toBeUndefined();
-        expect(getFilenameFromContentDisposition('other: filename=attachment.tsv')).toBeUndefined();
+            expect(requestHeaders['foo']).toEqual('bar');
+            expect(requestHeaders['X-LABKEY-CSRF']).toEqual(testCSRF); // it shouldn't lose other headers
+        });
     });
 
-    it('should find a file with the filename= prefix', () => {
-        expect(getFilenameFromContentDisposition('attachment; filename=data.xlsx')).toBe('data.xlsx');
-        expect(getFilenameFromContentDisposition('attachment; filename=d%20ata.xlsx')).toBe('d ata.xlsx');
+    describe('request method', () => {
+        mockXHR();
+
+        it('should default to GET', () => {
+            expect(request({ url: '/users' }).method).toEqual('GET');
+        });
+        it('should default to POST with data', () => {
+            expect(
+                request({
+                    url: '/users',
+                    jsonData: {
+                        userId: 123,
+                    },
+                }).method
+            ).toEqual('POST');
+        });
+        it('should accept GET with data', () => {
+            expect(
+                request({
+                    url: '/users',
+                    method: 'GET',
+                    jsonData: {
+                        userId: 123,
+                    },
+                }).method
+            ).toEqual('GET');
+        });
+        it('should accept any method', () => {
+            expect(request({ url: '/users', method: 'DELETE' }).method).toEqual('DELETE');
+            expect(request({ url: '/users', method: 'PUT' }).method).toEqual('PUT');
+            expect(request({ url: '/users', method: 'BEEP' }).method).toEqual('BEEP');
+        });
     });
 
-    it('should find a file with the filename*= prefix', () => {
-        expect(getFilenameFromContentDisposition('attachment; filename*=data.xlsx')).toBe('data.xlsx');
-        expect(getFilenameFromContentDisposition('attachment; filename*=d%20ata.xlsx')).toBe('d ata.xlsx');
-        expect(getFilenameFromContentDisposition("attachment; filename*=UTF-8''data.xlsx")).toBe('data.xlsx');
-        expect(getFilenameFromContentDisposition("attachment; filename*=UTF-8''d%20ata.xlsx")).toBe('d ata.xlsx');
-    });
+    describe('getFilenameFromContentDisposition', () => {
+        it('should not find a file if there is no attachment prefix', () => {
+            expect(getFilenameFromContentDisposition('other; filename=data.tsv')).toBeUndefined();
+            expect(getFilenameFromContentDisposition('other; filename=attachment.tsv')).toBeUndefined();
+        });
 
-    it('should use the first filename specified', () => {
-        expect(getFilenameFromContentDisposition('attachment; filename*=data.xlsx; filename=other.csv')).toBe(
-            'data.xlsx'
-        );
-        expect(getFilenameFromContentDisposition('attachment; filename=data.xlsx; filename*=other.csv')).toBe(
-            'data.xlsx'
-        );
-        expect(getFilenameFromContentDisposition("attachment; filename*=UTF-8''d%20ata.xlsx; filename=other.csv")).toBe(
-            'd ata.xlsx'
-        );
+        it('should not find a file if there is not a valid filename prefix', () => {
+            expect(getFilenameFromContentDisposition('attachment; filename=d ata.xl sx')).toBeUndefined();
+            expect(getFilenameFromContentDisposition('attachment; filename*=data.tsv')).toBeUndefined();
+            expect(getFilenameFromContentDisposition('attachment; filename*=attachment.tsv')).toBeUndefined();
+        });
+
+        it('should find a file with the filename= prefix', () => {
+            expect(getFilenameFromContentDisposition('attachment; filename=data.xlsx')).toBe('data.xlsx');
+            expect(getFilenameFromContentDisposition('attachment; filename="d ata.xl sx"')).toBe('d ata.xl sx');
+            expect(getFilenameFromContentDisposition('attachment;filename="plans.pdf" \t;    \t\t foo=bar')).toBe(
+                'plans.pdf'
+            );
+            expect(getFilenameFromContentDisposition('attachment; filename="£ rates.pdf"')).toBe('£ rates.pdf');
+        });
+
+        it('should find a file with the filename*= prefix', () => {
+            expect(
+                getFilenameFromContentDisposition("attachment; filename=data.xlsx; filename*=UTF-8''datastar.xlsx")
+            ).toBe('datastar.xlsx');
+            expect(
+                getFilenameFromContentDisposition('attachment; filename="d ata.xl sx"; filename*=utf-8\'\'d%20ata.xlsx')
+            ).toBe('d ata.xlsx');
+            expect(getFilenameFromContentDisposition("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf")).toBe(
+                '€ rates.pdf'
+            );
+            expect(
+                getFilenameFromContentDisposition("attachment; filename*=utf-8''data.xlsx; filename=other.csv")
+            ).toBe('data.xlsx');
+            expect(
+                getFilenameFromContentDisposition("attachment; filename=data.xlsx; filename*=utf-8''other.csv")
+            ).toBe('other.csv');
+            expect(
+                getFilenameFromContentDisposition("attachment; filename*=UTF-8''d%20ata.xlsx; filename=other.csv")
+            ).toBe('d ata.xlsx');
+            // Issue 50628: verify content-disposition parsing of filenames that include encoded characters
+            expect(
+                getFilenameFromContentDisposition(
+                    'attachment; filename="=?UTF-8?Q?ELN-1005-20240903-5523_London,_England.pdf?="; filename*=UTF-8\'\'ELN-1005-20240903-5523%20London%2C%20England.pdf'
+                )
+            ).toBe('ELN-1005-20240903-5523 London, England.pdf');
+        });
     });
 });

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -243,21 +243,25 @@ function configureOptions(config: RequestOptions): ConfiguredOptions {
  * Parse the filename out of the Content-Disposition header.
  *   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
  * Examples:
- *   Content-Disposition: attachment; filename=data.xlsx
- *   Content-Disposition: attachment; filename*=UTF-8''filename.xlsx
- *   Content-Disposition: attachment: filename=data.csv; filename*=UTF-8''filename.csv
- *   Content-Disposition: attachment: filename*=UTF-8''data.csv; filename=filename.csv
- * The pattern below will match the first filename provided (so, data.csv in the last two examples)
+ *   Content-Disposition: attachment; filename=data.xlsx;
+ *   Content-Disposition: attachment; filename*=UTF-8''filename.xlsx;
+ *   Content-Disposition: attachment; filename=data.csv; filename*=UTF-8''filename.csv;
+ *   Content-Disposition: attachment; filename=filename.csv; filename*=utf-8''data.csv;
  * Exported for jest testing
  * @hidden
  * @private
  */
 export function getFilenameFromContentDisposition(disposition: string): string {
-    const contentDisposition = parse(disposition);
-    if (!contentDisposition || contentDisposition.type !== 'attachment') {
+    try {
+        const contentDisposition = parse(disposition);
+        if (!contentDisposition || contentDisposition.type !== 'attachment') {
+            return undefined;
+        }
+
+        return contentDisposition.parameters.filename as string;
+    } catch (e) {
         return undefined;
     }
-    return contentDisposition.parameters.filename as string;
 }
 
 /**

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { parse } from '@tinyhttp/content-disposition';
+
 import { CSRF_HEADER, getServerContext } from './constants';
 import { buildURL, queryString } from './ActionURL';
 
@@ -251,14 +253,11 @@ function configureOptions(config: RequestOptions): ConfiguredOptions {
  * @private
  */
 export function getFilenameFromContentDisposition(disposition: string): string {
-    var filename;
-    if (disposition && disposition.startsWith('attachment')) {
-        const matches = /filename\*?=([^']*'')?(['"].*?['"]|[^;\n]*)/.exec(disposition);
-        if (matches && matches[2]) {
-            filename = decodeURI(matches[2].replace(/['"]/g, ''));
-        }
+    const contentDisposition = parse(disposition);
+    if (!contentDisposition || contentDisposition.type !== 'attachment') {
+        return undefined;
     }
-    return filename;
+    return contentDisposition.parameters.filename as string;
 }
 
 /**

--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -243,10 +243,10 @@ function configureOptions(config: RequestOptions): ConfiguredOptions {
  * Parse the filename out of the Content-Disposition header.
  *   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
  * Examples:
- *   Content-Disposition: attachment; filename=data.xlsx;
- *   Content-Disposition: attachment; filename*=UTF-8''filename.xlsx;
- *   Content-Disposition: attachment; filename=data.csv; filename*=UTF-8''filename.csv;
- *   Content-Disposition: attachment; filename=filename.csv; filename*=utf-8''data.csv;
+ *   Content-Disposition: attachment; filename=data.xlsx
+ *   Content-Disposition: attachment; filename*=UTF-8''filename.xlsx
+ *   Content-Disposition: attachment; filename=data.csv; filename*=UTF-8''filename.csv
+ *   Content-Disposition: attachment; filename=filename.csv; filename*=utf-8''data.csv
  * Exported for jest testing
  * @hidden
  * @private

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "lib": [ "dom", "es2015" ],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "moduleResolution": "node",
     "noEmit": false,
     "noImplicitAny": true,
@@ -9,6 +10,7 @@
     "resolveJsonModule": true,
     "rootDir": "src",
     "sourceMap": true,
-    "target": "ES5"
+    "target": "ES5",
+    "types": ["jest"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "moduleResolution": "node",

--- a/typedoc.js
+++ b/typedoc.js
@@ -5,24 +5,24 @@
  */
 module.exports = {
     cleanOutputDir: true,
-    entryPoints: ["src/index.ts"],
+    entryPoints: ['src/index.ts'],
     exclude: [
         // Tests
-        "**/*+(.spec).ts",
-        "**/test/**",
+        '**/*+(.spec).ts',
+        '**/test/**',
 
         // Sub-modules
-        "./src/labkey/dom/**",
+        './src/labkey/dom/**',
 
         // Wrappers
-        "./src/package.ts",
-        "./src/wrapper.ts",
-        "./src/wrapper-dom.ts",
+        './src/package.ts',
+        './src/wrapper.ts',
+        './src/wrapper-dom.ts',
     ],
     excludeExternals: true,
     excludePrivate: true,
     excludeProtected: true,
-    externalPattern: "**/node_modules/** ",
-    out: "docs",
-    theme: "default",
+    externalPattern: '**/node_modules/** ',
+    out: 'docs',
+    theme: 'default',
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,21 +4,17 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 'use strict';
+
 const path = require('path');
 
 const apiGlobalConfig = {
-
     mode: 'production',
 
     devtool: 'source-map',
 
     entry: {
-        'core': [
-            './src/wrapper.ts'
-        ],
-        'dom': [
-            './src/wrapper-dom.ts'
-        ]
+        core: ['./src/wrapper.ts'],
+        dom: ['./src/wrapper-dom.ts'],
     },
 
     module: {
@@ -27,23 +23,22 @@ const apiGlobalConfig = {
                 test: /^(?!.*spec\.ts?$).*\.ts?$/,
                 loader: 'ts-loader',
                 options: {
-                    onlyCompileBundledFiles: true
-                }
-            }
-        ]
+                    onlyCompileBundledFiles: true,
+                },
+            },
+        ],
     },
 
     output: {
-        filename: 'labkey-api-js-[name].min.js'
+        filename: 'labkey-api-js-[name].min.js',
     },
 
     resolve: {
-        extensions: [ '.ts' ]
-    }
+        extensions: ['.ts'],
+    },
 };
 
 const umdPackageConfig = {
-
     entry: './src/index.ts',
 
     mode: 'production',
@@ -51,7 +46,7 @@ const umdPackageConfig = {
     target: 'web',
 
     devtool: 'source-map',
-    
+
     module: {
         rules: [
             {
@@ -64,31 +59,28 @@ const umdPackageConfig = {
                         removeComments: true,
                         target: 'ES6',
                     },
-                    onlyCompileBundledFiles: true
+                    onlyCompileBundledFiles: true,
                 },
-                exclude: /node_modules/
-            }
-        ]
+                exclude: /node_modules/,
+            },
+        ],
     },
 
     optimization: {
         // don't minimize; module/app usages will be doing that if they want to
-        minimize: false
+        minimize: false,
     },
 
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'index.js',
         library: '@labkey/api',
-        libraryTarget: 'umd'
+        libraryTarget: 'umd',
     },
 
     resolve: {
-        extensions: [ '.ts' ]
-    }
+        extensions: ['.ts'],
+    },
 };
 
-module.exports = [
-    apiGlobalConfig,
-    umdPackageConfig
-];
+module.exports = [apiGlobalConfig, umdPackageConfig];


### PR DESCRIPTION
#### Rationale
This addresses [Issue 50628](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50628) by switching our "Content-Disposition" header parsing to utilize the [@tinyhttp/content-disposition](https://www.npmjs.com/package/@tinyhttp/content-disposition) package. See the issue for more details.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/182
- https://github.com/LabKey/labkey-ui-components/pull/1575
- https://github.com/LabKey/limsModules/pull/698
- https://github.com/LabKey/platform/pull/5853

#### Changes
- Add `@tinyhttp/content-disposition` to `devDependencies` and bundle its implementation into `@labkey/api` distributions. The `@tinyhttp/content-disposition` package does not have any additional dependencies and the inline implementation is small (5 Kb, 3Kb minified).
- Add `@babel/plugin-transform-modules-commonjs` to `devDependencies` for transpiling of ES modules that are imported during jest test runs.
- Switch implementation of `Ajax.getFilenameFromContentDisposition()` to utilize `parse` from `@tinyhttp/content-disposition`.
- Update jest configuration to support ES module dependencies
- Update and add additional unit test coverage for content-disposition parsing.