### PR TITLE
Datetime formats - app ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.X - 2024-10-X
+- Add "includeInheritableFormats" property to GetContainersOptions
+
 ### 1.35.2 - 2024-10-04
 - Add "inheritable" property to VisualizationGetResponse
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.X - 2024-10-X
+### 1.35.3 - 2024-10-22
 - Add "includeInheritableFormats" property to GetContainersOptions
 
 ### 1.35.2 - 2024-10-04

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.3-fb-datetime-formats.2",
+  "version": "1.35.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.3-fb-datetime-formats.2",
+      "version": "1.35.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.2",
+  "version": "1.35.3-fb-datetime-formats.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.2",
+      "version": "1.35.3-fb-datetime-formats.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.2",
+  "version": "1.35.3-fb-datetime-formats.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.3-fb-datetime-formats.2",
+  "version": "1.35.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/Container.ts
+++ b/src/labkey/security/Container.ts
@@ -183,7 +183,7 @@ export interface GetContainersOptions extends RequestCallbackOptions /* <Contain
      */
     includeWorkbookChildren?: boolean;
     /**
-     * If set to true, will include properties about the inherited state of the formats as well as formats from parent folders that can be inherited
+     * If set to true, will include properties about the inherited state of the formats as well as formats from parent folders that can be inherited.
      */
     includeInheritableFormats?: boolean;
     /**

--- a/src/labkey/security/Container.ts
+++ b/src/labkey/security/Container.ts
@@ -183,6 +183,10 @@ export interface GetContainersOptions extends RequestCallbackOptions /* <Contain
      */
     includeWorkbookChildren?: boolean;
     /**
+     * If set to true, will include properties about the inherited state of the formats as well as formats from parent folders that can be inherited
+     */
+    includeInheritableFormats?: boolean;
+    /**
      * The names (Strings) of modules whose Module Property values should be included for each container.
      * Use "*" to get the value of all Module Properties for all modules.
      */
@@ -230,6 +234,9 @@ export function getContainers(config: GetContainersOptions): XMLHttpRequest {
         }
         if (config.includeStandardProperties != undefined) {
             params.includeStandardProperties = config.includeStandardProperties;
+        }
+        if (config.includeInheritableFormats != undefined) {
+            params.includeInheritableFormats = config.includeInheritableFormats;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Add "includeInheritableFormats" property to GetContainersOptions to support showing inherited value on UI

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/184
- https://github.com/LabKey/platform/pull/5923
- https://github.com/LabKey/labkey-ui-components/pull/1607
- https://github.com/LabKey/labkey-ui-premium/pull/563
- https://github.com/LabKey/limsModules/pull/826
- https://github.com/LabKey/testAutomation/pull/2099
- https://github.com/LabKey/premiumModules/pull/76
- https://github.com/LabKey/ehrModules/pull/844
- https://github.com/LabKey/snprcEHRModules/pull/762

#### Changes
* Add "includeInheritableFormats" property to GetContainersOptions