### PR TITLE
Issue 51293: remove useExperimentalCoreUI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.35.4 - 2024-10-22
+### 1.35.4 - 2024-10-28
 - Issue 51293: remove typings reference to `useExperimentalCoreUI` experimental flag
 
 ### 1.35.3 - 2024-10-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.35.4 - 2024-10-22
+- Issue 51293: remove typings reference to `useExperimentalCoreUI` experimental flag
+
 ### 1.35.3 - 2024-10-22
 - Add "includeInheritableFormats" property to GetContainersOptions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.4-fb-ui-flag.0",
+  "version": "1.35.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.4-fb-ui-flag.0",
+      "version": "1.35.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.3",
+  "version": "1.35.4-fb-ui-flag.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.3",
+      "version": "1.35.4-fb-ui-flag.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.3",
+  "version": "1.35.4-fb-ui-flag.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.4-fb-ui-flag.0",
+  "version": "1.35.4",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -76,7 +76,6 @@ export enum ExperimentalFeatures {
     disableGuestAccount = 'disableGuestAccount',
     javascriptErrorServerLogging = 'javascriptErrorServerLogging',
     javascriptMothership = 'javascriptMothership',
-    useExperimentalCoreUI = 'useExperimentalCoreUI',
 }
 
 /** THe different types of audit behaviors for query requests. May be used to override behavior for a specific requests. */


### PR DESCRIPTION
#### Rationale
Removes reference to a long since incorporated experimental flag. Addresses [Issue 51293](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51293).

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/186
- https://github.com/LabKey/labkey-ui-components/pull/1622
- https://github.com/LabKey/platform/pull/5996
- https://github.com/LabKey/nlp/pull/253

#### Changes
- Remove typings reference to `useExperimentalCoreUI` experimental flag.
