### PR TITLE
Assay support for including sample identifying fields in editable grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### TBD
+### 1.35.6 - 2024-10-31
 - Add "saveMatchingColumnDataOnly" property to ImportRunOptions
 
 ### 1.35.5 - 2024-10-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### TBD
+- Add "saveMatchingColumnDataOnly" property to ImportRunOptions
+
 ### 1.35.3 - 2024-10-22
 - Add "includeInheritableFormats" property to GetContainersOptions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.5-fb-identSampleFieldAssay.0",
+  "version": "1.35.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.5-fb-identSampleFieldAssay.0",
+      "version": "1.35.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.4-fb-identSampleFieldAssay.0",
+  "version": "1.35.5-fb-identSampleFieldAssay.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.4-fb-identSampleFieldAssay.0",
+      "version": "1.35.5-fb-identSampleFieldAssay.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.4",
+  "version": "1.35.4-fb-identSampleFieldAssay.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.4",
+      "version": "1.35.4-fb-identSampleFieldAssay.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.3",
+  "version": "1.35.3-fb-identSampleFieldAssay.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.35.3",
+      "version": "1.35.3-fb-identSampleFieldAssay.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.4",
+  "version": "1.35.4-fb-identSampleFieldAssay.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.3",
+  "version": "1.35.3-fb-identSampleFieldAssay.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.5-fb-identSampleFieldAssay.0",
+  "version": "1.35.6",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.35.5",
+  "version": "1.35.5-fb-identSampleFieldAssay.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -39,6 +39,7 @@ export interface ImportRunOptions extends RequestCallbackOptions {
     resultsFiles?: File[];
     runFilePath?: string;
     saveDataAsFile?: boolean;
+    saveMatchingColumnDataOnly?: boolean;
     workflowTask?: number;
 }
 
@@ -89,6 +90,9 @@ export function importRun(options: ImportRunOptions): XMLHttpRequest {
     }
     if (options.saveDataAsFile !== undefined) {
         formData.append('saveDataAsFile', options.saveDataAsFile ? 'true' : 'false');
+    }
+    if (options.saveMatchingColumnDataOnly !== undefined) {
+        formData.append('saveMatchingColumnDataOnly', options.saveMatchingColumnDataOnly ? 'true' : 'false');
     }
     if (options.jobDescription) {
         formData.append('jobDescription', options.jobDescription);


### PR DESCRIPTION
#### Rationale
See related PR for rationale. This PR just adds a prop to ImportRunOptions for the assay run import API.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1624

#### Changes
- Add "saveMatchingColumnDataOnly" property to ImportRunOptions
