### PR TITLE
ActionURL.queryString: Add support for numbers, booleans, and mixed arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 1.41.0 - 2025-05-??
-- ActionURL.queryString: Add support for numbers, and mixed arrays
+- ActionURL.queryString: Add support for numbers, booleans, and mixed arrays
 
 ### 1.40.0 - 2025-04-21
 - Package updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.41.0 - 2025-05-??
+### 1.41.0 - 2025-05-22
 - ActionURL.queryString: Add support for numbers, booleans, and mixed arrays
 
 ### 1.40.0 - 2025-04-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.41.0 - 2025-05-??
+- ActionURL.queryString: Add support for numbers, and mixed arrays
+
 ### 1.40.0 - 2025-04-21
 - Package updates
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.40.0",
+      "version": "1.41.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.26.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -210,9 +210,11 @@ describe('ActionURL', () => {
                 strParam: 'My&String Value',
                 numParam: 1,
                 'array Param': ['value&one', 'value two', 'valueThree', 1, 2.2, 3.34],
+                nullParam: null,
+                undefinedParam: undefined,
             };
             const expected =
-                'strParam=My%26String%20Value&numParam=1&array%20Param=value%26one&array%20Param=value%20two&array%20Param=valueThree&array%20Param=1&array%20Param=2.2&array%20Param=3.34';
+                'strParam=My%26String%20Value&numParam=1&array%20Param=value%26one&array%20Param=value%20two&array%20Param=valueThree&array%20Param=1&array%20Param=2.2&array%20Param=3.34&nullParam=&undefinedParam=';
             expect(queryString(params)).toEqual(expected);
         });
     });

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -205,16 +205,25 @@ describe('ActionURL', () => {
             ).toEqual(expected);
         });
 
+        test('supports boolean', () => {
+            let expected = 'paramOne=true';
+            expect(queryString({ paramOne: true })).toEqual(expected);
+
+            expected = 'paramOne=true&param%20Two=false';
+            expect(queryString({ paramOne: true, 'param Two': false })).toEqual(expected);
+        });
+
         test('supports everything', () => {
             const params: Record<string, any> = {
                 strParam: 'My&String Value',
                 numParam: 1,
-                'array Param': ['value&one', 'value two', 'valueThree', 1, 2.2, 3.34],
+                'array Param': ['value&one', 'value two', 'valueThree', 1, 2.2, 3.34, true],
                 nullParam: null,
                 undefinedParam: undefined,
+                boolParam: false,
             };
             const expected =
-                'strParam=My%26String%20Value&numParam=1&array%20Param=value%26one&array%20Param=value%20two&array%20Param=valueThree&array%20Param=1&array%20Param=2.2&array%20Param=3.34&nullParam=&undefinedParam=';
+                'strParam=My%26String%20Value&numParam=1&array%20Param=value%26one&array%20Param=value%20two&array%20Param=valueThree&array%20Param=1&array%20Param=2.2&array%20Param=3.34&array%20Param=true&nullParam=&undefinedParam=&boolParam=false';
             expect(queryString(params)).toEqual(expected);
         });
     });

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -15,6 +15,7 @@
  */
 import * as ActionURL from './ActionURL';
 import { getServerContext } from './constants';
+import { queryString } from './ActionURL';
 
 describe('ActionURL', () => {
     const CONTAINER_NAME = 'DefaultContainer';
@@ -150,6 +151,69 @@ describe('ActionURL', () => {
                 'pipeline-status',
                 'action'
             );
+        });
+    });
+
+    describe('queryString', () => {
+        test('empty object returns empty string', () => {
+            expect(queryString()).toEqual('');
+            expect(queryString(undefined)).toEqual('');
+            expect(queryString({})).toEqual('');
+        });
+
+        test('supports null values', () => {
+            let expected = 'paramOne=';
+            expect(queryString({ paramOne: null })).toEqual(expected);
+
+            expected = 'paramOne=&paramTwo=';
+            expect(queryString({ paramOne: null, paramTwo: undefined })).toEqual(expected);
+        });
+
+        test('supports strings', () => {
+            let expected = 'paramOne=valueOne';
+            expect(queryString({ paramOne: 'valueOne' })).toEqual(expected);
+
+            expected = 'paramOne=valueOne&paramTwo=valueTwo';
+            expect(queryString({ paramOne: 'valueOne', paramTwo: 'valueTwo' })).toEqual(expected);
+
+            expected = 'encoded%20Param%20One=encoded%20Value%20One&paramTwo=valueTwo';
+            expect(queryString({ 'encoded Param One': 'encoded Value One', paramTwo: 'valueTwo' })).toEqual(expected);
+        });
+
+        test('supports numbers', () => {
+            let expected = 'paramOne=1';
+            expect(queryString({ paramOne: 1 })).toEqual(expected);
+
+            expected = 'paramOne=1&paramTwo=2.2';
+            expect(queryString({ paramOne: 1, paramTwo: 2.2 })).toEqual(expected);
+
+            expected = 'encoded%20Param%20One=1&paramTwo=2.34';
+            expect(queryString({ 'encoded Param One': 1, paramTwo: 2.34 })).toEqual(expected);
+        });
+
+        test('supports arrays', () => {
+            let expected = 'paramOne=v1&paramOne=v2&paramOne=v3';
+            expect(queryString({ paramOne: ['v1', 'v2', 'v3'] })).toEqual(expected);
+
+            expected = 'paramOne=v1&paramOne=v2&paramOne=v3&paramTwo=1&paramTwo=2&paramTwo=3';
+            expect(queryString({ paramOne: ['v1', 'v2', 'v3'], paramTwo: [1, 2, 3] })).toEqual(expected);
+
+            expected =
+                'encoded%20Param%20One=p%261&encoded%20Param%20One=p%262&encoded%20Param%20One=p%263&paramTwo=one&paramTwo=v%202&paramTwo=2.2&paramTwo=3.3';
+            expect(
+                queryString({ 'encoded Param One': ['p&1', 'p&2', 'p&3'], paramTwo: ['one', 'v 2', 2.2, 3.3] })
+            ).toEqual(expected);
+        });
+
+        test('supports everything', () => {
+            const params = {
+                strParam: 'My&String Value',
+                numParam: 1,
+                'array Param': ['value&one', 'value two', 'valueThree', 1, 2.2, 3.34],
+            };
+            const expected =
+                'strParam=My%26String%20Value&numParam=1&array%20Param=value%26one&array%20Param=value%20two&array%20Param=valueThree&array%20Param=1&array%20Param=2.2&array%20Param=3.34';
+            expect(queryString(params)).toEqual(expected);
         });
     });
 });

--- a/src/labkey/ActionURL.spec.ts
+++ b/src/labkey/ActionURL.spec.ts
@@ -206,7 +206,7 @@ describe('ActionURL', () => {
         });
 
         test('supports everything', () => {
-            const params = {
+            const params: Record<string, any> = {
                 strParam: 'My&String Value',
                 numParam: 1,
                 'array Param': ['value&one', 'value two', 'valueThree', 1, 2.2, 3.34],

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -375,11 +375,11 @@ export function getReturnUrl(): string {
     return getParameter('returnUrl');
 }
 
-function encodeParamValue(key: string, value: string | number): string {
+function encodeParamValue(key: string, value: string | number | boolean): string {
     return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
 }
 
-type BaseQueryParamValue = string | number | null | undefined;
+type BaseQueryParamValue = string | number | boolean | null | undefined;
 type QueryParamValue = BaseQueryParamValue | BaseQueryParamValue[];
 
 /**

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -375,6 +375,10 @@ export function getReturnUrl(): string {
     return getParameter('returnUrl');
 }
 
+function encodeParamValue(key: string, value: string | number): string {
+    return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+}
+
 /**
  * Turn the parameter object into a query string (e.g. `{x:'fred'} -> "x=fred"`).
  * The returned query string is not prepended by a question mark ('?').
@@ -383,41 +387,25 @@ export function getReturnUrl(): string {
  * Parameters will be encoded automatically. Parameter values that are arrays will be appended as multiple parameters
  * with the same name. (Defaults to no parameters.)
  */
-export function queryString(parameters?: Record<string, string | string[]>): string {
-    if (!parameters) {
-        return '';
-    }
+export function queryString(parameters?: Record<string, string | number | Array<string | number>>): string {
+    if (!parameters) return '';
 
-    let query = '',
-        and = '',
-        pval: string | string[],
-        parameter: string,
-        aval: string;
+    const parts = Object.keys(parameters).reduce((result: string[], key) => {
+        let value = parameters[key];
 
-    for (parameter in parameters) {
-        if (parameters.hasOwnProperty(parameter)) {
-            pval = parameters[parameter];
+        if (isFunction(value)) return result;
+        if (value === null || value === undefined) value = '';
 
-            if (pval === null || pval === undefined) {
-                pval = '';
-            } else if (isFunction(pval)) {
-                continue;
-            }
-
-            if (isArray(pval)) {
-                for (let idx = 0; idx < pval.length; ++idx) {
-                    aval = pval[idx];
-                    query += and + encodeURIComponent(parameter) + '=' + encodeURIComponent(pval[idx]);
-                    and = '&';
-                }
-            } else {
-                query += and + encodeURIComponent(parameter) + '=' + encodeURIComponent(pval as string);
-                and = '&';
-            }
+        if (Array.isArray(value)) {
+            value.forEach(aVal => result.push(encodeParamValue(key, aVal)));
+        } else {
+            result.push(encodeParamValue(key, value));
         }
-    }
 
-    return query;
+        return result;
+    }, []);
+
+    return parts.join('&');
 }
 
 /**

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -379,6 +379,9 @@ function encodeParamValue(key: string, value: string | number): string {
     return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
 }
 
+type BaseQueryParamValue = string | number | null | undefined;
+type QueryParamValue = BaseQueryParamValue | BaseQueryParamValue[];
+
 /**
  * Turn the parameter object into a query string (e.g. `{x:'fred'} -> "x=fred"`).
  * The returned query string is not prepended by a question mark ('?').
@@ -387,7 +390,7 @@ function encodeParamValue(key: string, value: string | number): string {
  * Parameters will be encoded automatically. Parameter values that are arrays will be appended as multiple parameters
  * with the same name. (Defaults to no parameters.)
  */
-export function queryString(parameters?: Record<string, string | number | Array<string | number>>): string {
+export function queryString(parameters?: Record<string, QueryParamValue>): string {
     if (!parameters) return '';
 
     const parts = Object.keys(parameters).reduce((result: string[], key) => {
@@ -396,11 +399,8 @@ export function queryString(parameters?: Record<string, string | number | Array<
         if (isFunction(value)) return result;
         if (value === null || value === undefined) value = '';
 
-        if (Array.isArray(value)) {
-            value.forEach(aVal => result.push(encodeParamValue(key, aVal)));
-        } else {
-            result.push(encodeParamValue(key, value));
-        }
+        if (Array.isArray(value)) value.forEach(aVal => result.push(encodeParamValue(key, aVal)));
+        else result.push(encodeParamValue(key, value));
 
         return result;
     }, []);


### PR DESCRIPTION
#### Rationale
ActionURL.queryString has always supported these values, however the types do not align. This PR updates the types to align with what we actually support, adds tests, and simplifies the queryString method.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1790
- https://github.com/LabKey/labkey-ui-premium/pull/748
- https://github.com/LabKey/platform/pull/6639
- https://github.com/LabKey/limsModules/pull/1393
- https://github.com/LabKey/testAutomation/pull/2458

#### Changes
* ActionURL.queryString: add support for number, boolean, and mixed arrays
    * Also simplified code
    * Also added test cases