### PR TITLE
Issue 53150: LABKEY.Utils.isBoolean is not tolerant of undefined/null parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.41.2 - 2025-05-28
+- Update `isBoolean` to directly check for boolean type and be tolerant of undefined/null value.
+- Switch `isArray` to be `Array.isArray`. Deprecate.
+- Switch `isNumber` to be `Number.isNumber`. Deprecate.
+- Update `isDate` to act as a `Date` type check returning `value is Date`.
+
 ### 1.41.1 - 2025-05-22
 - Add `auditUserComment` to `Domain.drop` and `Domain.save`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.41.1",
+  "version": "1.41.2-fb-jnk-except.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.41.1",
+      "version": "1.41.2-fb-jnk-except.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.26.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.41.2-fb-jnk-except.0",
+  "version": "1.41.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.41.2-fb-jnk-except.0",
+      "version": "1.41.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.26.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.41.2-fb-jnk-except.0",
+  "version": "1.41.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.41.1",
+  "version": "1.41.2-fb-jnk-except.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/ActionURL.ts
+++ b/src/labkey/ActionURL.ts
@@ -293,7 +293,7 @@ function fullyDecodeURIPath(path: string): string {
 }
 
 /**
- * Parses a location pathname of a LabKey URL into its constituent parts (e.g. controller, action, etc).
+ * Parses a location pathname of a LabKey URL into its constituent parts (e.g. controller, action, etc.).
  * Defaults to the current location's pathname and context path. The parsed parts of the {@link ActionPath} are
  * URI decoded.
  * #### Example
@@ -379,8 +379,8 @@ function encodeParamValue(key: string, value: string | number | boolean): string
     return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
 }
 
-type BaseQueryParamValue = string | number | boolean | null | undefined;
-type QueryParamValue = BaseQueryParamValue | BaseQueryParamValue[];
+export type BaseQueryParamValue = string | number | boolean | null | undefined;
+export type QueryParamValue = BaseQueryParamValue | BaseQueryParamValue[];
 
 /**
  * Turn the parameter object into a query string (e.g. `{x:'fred'} -> "x=fred"`).

--- a/src/labkey/Utils.spec.ts
+++ b/src/labkey/Utils.spec.ts
@@ -165,6 +165,11 @@ describe('isArray', () => {
 });
 
 describe('isBoolean', () => {
+    it('should return false for undefined/null', () => {
+        expect(Utils.isBoolean(undefined)).toBe(false);
+        expect(Utils.isBoolean(null)).toBe(false);
+        expect(Utils.isBoolean('')).toBe(false);
+    });
     it('should accept y/n', () => {
         expect(Utils.isBoolean('y')).toBe(true);
         expect(Utils.isBoolean('n')).toBe(true);
@@ -184,6 +189,15 @@ describe('isBoolean', () => {
     it('should accept boolean', () => {
         expect(Utils.isBoolean(true)).toBe(true);
         expect(Utils.isBoolean(false)).toBe(true);
+    });
+    it('should accept 1 and 0 as boolean-like', () => {
+        expect(Utils.isBoolean(1)).toBe(true);
+        expect(Utils.isBoolean(0)).toBe(true);
+    });
+    it('should return false for unrelated strings', () => {
+        expect(Utils.isBoolean('maybe')).toBe(false);
+        expect(Utils.isBoolean('random')).toBe(false);
+        expect(Utils.isBoolean('2')).toBe(false);
     });
 });
 

--- a/src/labkey/Utils.ts
+++ b/src/labkey/Utils.ts
@@ -636,10 +636,11 @@ export function id(prefix?: string): string {
     return ID_PREFIX + ++idSeed;
 }
 
-export function isArray(value: any): boolean {
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray
-    return Object.prototype.toString.call(value) === '[object Array]';
-}
+/**
+ * Returns true if the passed value is an Array.
+ * @deprecated Use `Array.isArray()`
+ */
+export const isArray = Array.isArray;
 
 /**
  * Tests whether the passed value can be used as boolean, using a loose definition.
@@ -649,33 +650,26 @@ export function isArray(value: any): boolean {
  * @param value The value to test
  * @returns {boolean}
  */
-export function isBoolean(value: any): boolean {
-    const upperVal = value.toString().toUpperCase();
-    if (
-        upperVal == 'TRUE' ||
-        value == '1' ||
-        upperVal == 'Y' ||
-        upperVal == 'YES' ||
-        upperVal == 'ON' ||
-        upperVal == 'T' ||
-        upperVal == 'FALSE' ||
-        value == '0' ||
-        upperVal == 'N' ||
-        upperVal == 'NO' ||
-        upperVal == 'OFF' ||
-        upperVal == 'F'
-    ) {
-        return true;
-    }
+export function isBoolean(value: unknown): value is boolean {
+    if (typeof value === 'boolean') return true;
+    const normalized = value?.toString().toUpperCase();
+    const booleanStrings = new Set(['TRUE', 'FALSE', '1', '0', 'Y', 'N', 'YES', 'NO', 'ON', 'OFF', 'T', 'F']);
+    return booleanStrings.has(normalized);
 }
 
-export function isDate(value: any): boolean {
+/**
+ * Returns true if the passed value is a Date.
+ */
+export function isDate(value: unknown): value is Date {
     return Object.prototype.toString.call(value) === '[object Date]';
 }
 
-export function isNumber(value: any): boolean {
-    return typeof value === 'number' && Number.isFinite(value);
-}
+/**
+ * Returns true if the passed value is a finite number.
+ * @deprecated Use `Number.isFinite()`.
+ * @param value
+ */
+export const isNumber = Number.isFinite;
 
 export function isDefined(value: any): boolean {
     return typeof value !== 'undefined';

--- a/src/labkey/Utils.ts
+++ b/src/labkey/Utils.ts
@@ -340,7 +340,7 @@ export function encode(data: any): string {
  * by the browser. For example, if your input string was "&lt;p&gt;Hello&lt;/p&gt;" the output would be
  * "&amp;lt;p&amp;gt;Hello&amp;lt;/p&amp;gt;". If you set an element's innerHTML property
  * to this string, the HTML markup will be displayed as literal text rather than being
- * interpreted as HTML. By default this function will return an empty string if a value
+ * interpreted as HTML. By default, this function will return an empty string if a value
  * of undefined or null is passed it. To prevent this default, you can pass in a second
  * optional parameter value of true to retain the empty value's type.
  *
@@ -595,13 +595,12 @@ export function getMsgFromError(response: XMLHttpRequest, exceptionObj: any, con
 
 /**
  *
- * Standard documented name for error callback arguments is "failure" but various other names have been employed in past.
+ * Standard documented name for error callback arguments is "failure" but various other names have been employed in the past.
  * This function provides reverse compatibility by picking the failure callback argument out of a config object
  * be it named failure, failureCallback or errorCallback.
  */
 export function getOnFailure(config: { errorCallback?: any; failure?: any; failureCallback?: any }): any {
     return config.failure || config.errorCallback || config.failureCallback;
-    // maybe it be desirable for this fall all the way back to returning LABKEY.Utils.displayAjaxErrorResponse?
 }
 
 /**
@@ -676,7 +675,7 @@ export function isDefined(value: any): boolean {
 }
 
 /**
- * Returns true if the passed object is empty (ie. `{}`) and false if not.
+ * Returns true if the passed object is empty (i.e. `{}`) and false if not.
  * @param obj The object to test
  * @return The result of the test
  */


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53150](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53150) by making `isBoolean` tolerant of undefined/null values. Additionally, updates other utilities.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/196
- https://github.com/LabKey/labkey-ui-components/pull/1798
- https://github.com/LabKey/labkey-ui-premium/pull/760
- https://github.com/LabKey/limsModules/pull/1427
- https://github.com/LabKey/platform/pull/6697

#### Changes
- Update `isBoolean` to directly check for boolean type and be tolerant of undefined/null value.
- Switch `isArray` to be `Array.isArray`. Deprecate.
- Switch `isNumber` to be `Number.isNumber`. Deprecate.
- Update `isDate` to act as a `Date` type check returning `value is Date`.
- Export `BaseQueryParamValue` and `QueryParamValue` so they are available in documentation.
