### PR TITLE
Issue 53243: add "includeEmptyPermGroups" to getGroupPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.42.1 - 2025-07-24
+- Issue 53243: add "includeEmptyPermGroups" to getGroupPermissions
+
 ### 1.42.0 - 2025-06-24
 - Package updates
 - Update ESLint configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.42.1-fb-aliquot-53153.0",
+  "version": "1.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.42.1-fb-aliquot-53153.0",
+      "version": "1.42.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.27.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.42.0",
+  "version": "1.42.1-fb-aliquot-53153.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.42.0",
+      "version": "1.42.1-fb-aliquot-53153.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.27.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.42.1-fb-aliquot-53153.0",
+  "version": "1.42.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.42.0",
+  "version": "1.42.1-fb-aliquot-53153.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/security/Permission.ts
+++ b/src/labkey/security/Permission.ts
@@ -46,6 +46,8 @@ export interface GetGroupPermissionsOptions extends RequestCallbackOptions<Permi
      * the current container path will be used.
      */
     containerPath?: string;
+    /** Set to false to exclude groups that have no effective permissions (defaults to true) */
+    includeEmptyPermGroups?: boolean;
     /** Set to true to recurse down the subfolders (defaults to false) */
     includeSubfolders?: boolean;
 }
@@ -64,6 +66,9 @@ export function getGroupPermissions(config: GetGroupPermissionsOptions): XMLHttp
 
     if (config.includeSubfolders != undefined) {
         params.includeSubfolders = config.includeSubfolders;
+    }
+    if (config.includeEmptyPermGroups != undefined) {
+        params.includeEmptyPermGroups = config.includeEmptyPermGroups;
     }
 
     return request({


### PR DESCRIPTION
#### Rationale
This adds support for the `includeEmptyPermGroups` flag to the `security-getGroupPerms.api` endpoint wrapper.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6853

#### Changes
- Check for `includeEmptyPermGroups` and add to payload if specified
