### PR TITLE
Add auditing of what method was used for data imports, updates, deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.43.1 - 2025-X
+- Command and QueryRequestOptions: add auditDetails parameter
+
 ### 1.43.0 - 2025-08-29
 - Support `File` values directly in `Assay.importRun()` for `batchProperties` and (run) `properties`
 - Can only be run with corresponding server-side changes in LabKey v25.09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.43.1 - 2025-X
+### 1.43.2 - 2025-11-02
 - Command and QueryRequestOptions: add auditDetails parameter
 
 ### 1.43.1 - 2025-10-31

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.1-fb-transactionAuditDetails.1",
+  "version": "1.43.1-fb-transactionAuditDetails.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.43.1-fb-transactionAuditDetails.1",
+      "version": "1.43.1-fb-transactionAuditDetails.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.27.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.2-fb-transactionAuditDetails.1",
+  "version": "1.43.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.43.2-fb-transactionAuditDetails.1",
+      "version": "1.43.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.27.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.0",
+  "version": "1.43.1-fb-transactionAuditDetails.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.43.0",
+      "version": "1.43.1-fb-transactionAuditDetails.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.27.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.1-fb-transactionAuditDetails.5",
+  "version": "1.43.1-fb-transactionAuditDetails.6",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.2-fb-transactionAuditDetails.1",
+  "version": "1.43.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.1-fb-transactionAuditDetails.2",
+  "version": "1.43.1-fb-transactionAuditDetails.5",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.0",
+  "version": "1.43.1-fb-transactionAuditDetails.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.1-fb-transactionAuditDetails.1",
+  "version": "1.43.1-fb-transactionAuditDetails.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -43,6 +43,7 @@ export interface ImportRunOptions extends RequestCallbackOptions {
     allowLookupByAlternateKey?: boolean;
     assayId?: number | string;
     auditUserComment?: string;
+    auditDetails?: any;
     batchId?: number | string;
     batchProperties?: Record<string, any>;
     comment?: string;
@@ -135,6 +136,9 @@ export function importRun(options: ImportRunOptions): XMLHttpRequest {
     }
     if (options.auditUserComment !== undefined) {
         formData.append('auditUserComment', options.auditUserComment);
+    }
+    if (options.auditDetails !== undefined) {
+        formData.append('auditDetails', JSON.stringify(options.auditDetails));
     }
 
     appendProperties('batchProperties', formData, options.batchProperties);

--- a/src/labkey/dom/Assay.ts
+++ b/src/labkey/dom/Assay.ts
@@ -43,7 +43,7 @@ export interface ImportRunOptions extends RequestCallbackOptions {
     allowLookupByAlternateKey?: boolean;
     assayId?: number | string;
     auditUserComment?: string;
-    auditDetails?: any;
+    auditDetails?: Record<string, any>;
     batchId?: number | string;
     batchProperties?: Record<string, any>;
     comment?: string;

--- a/src/labkey/dom/Query.ts
+++ b/src/labkey/dom/Query.ts
@@ -95,7 +95,7 @@ export function exportTables(options: IExportTablesOptions): void {
 }
 
 export interface IImportDataOptions {
-    auditDetails?: any;
+    auditDetails?: Record<string, any>;
     auditUserComment?: string;
     containerPath?: string;
     failure?: Function;

--- a/src/labkey/dom/Query.ts
+++ b/src/labkey/dom/Query.ts
@@ -95,6 +95,7 @@ export function exportTables(options: IExportTablesOptions): void {
 }
 
 export interface IImportDataOptions {
+    auditDetails?: any;
     auditUserComment?: string;
     containerPath?: string;
     failure?: Function;
@@ -160,6 +161,9 @@ export function importData(options: IImportDataOptions): XMLHttpRequest {
     }
     if (options.auditUserComment !== undefined) {
         form.append('auditUserComment', options.auditUserComment);
+    }
+    if (options.auditDetails !== undefined) {
+        form.append('auditDetails', JSON.stringify(options.auditDetails));
     }
 
     if (options.file) {

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -22,6 +22,8 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
     apiVersion?: number | string;
     /** Can be used to override the audit behavior for the table the query is acting on. See {@link AuditBehaviorTypes}. */
     auditBehavior?: AuditBehaviorTypes;
+    /** Optional audit details to record in the transaction audit log for this command. */
+    auditDetails?: any;
     /** Can be used to provide a comment from the user that will be attached to certain detailed audit log records. */
     auditUserComment?: string;
     /**
@@ -213,6 +215,10 @@ export interface ModifyRowsResults {
 export interface Command {
     /** Can be used to override the audit behavior for the table the Command is acting on. See{@link AuditBehaviorTypes}. */
     auditBehavior?: AuditBehaviorTypes;
+
+    /** Optional audit details to record in the transaction audit log for this command. */
+    auditDetails?: any;
+
     /** Can be used to provide a comment from the user that will be attached to certain detailed audit log records. */
     auditUserComment?: string;
     /** Name of the command to be performed. Must be one of "insert", "update", or "delete". */
@@ -449,6 +455,7 @@ function sendRequest(options: SendRequestOptions, supportsFiles?: boolean): XMLH
         transacted: options.transacted,
         extraContext: options.extraContext,
         auditBehavior: options.auditBehavior,
+        auditDetails: options.auditDetails,
         auditUserComment: options.auditUserComment,
         skipReselectRows: options.skipReselectRows,
     };
@@ -517,6 +524,7 @@ export function moveRows(options: MoveRowsOptions): XMLHttpRequest {
         queryName: options.queryName,
         rows: options.rows,
         auditBehavior: options.auditBehavior,
+        auditDetails: options.auditDetails,
         auditUserComment: options.auditUserComment,
         dataRegionSelectionKey: options.dataRegionSelectionKey,
         useSnapshotSelection: options.useSnapshotSelection,

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -273,6 +273,11 @@ export interface SaveRowsResponse {
 }
 
 export interface SaveRowsOptions extends RequestCallbackOptions<SaveRowsResponse> {
+
+    /**
+     * Optional audit details to record in the transaction audit log for this command.
+     */
+    auditDetails?: any;
     /**
      * Version of the API. If this is 13.2 or higher, a request that fails
      * validation will be returned as a successful response. Use the 'errorCount' and 'committed' properties in the
@@ -370,6 +375,7 @@ export function saveRows(options: SaveRowsOptions): XMLHttpRequest {
     //     options = queryArguments(arguments);
     // }
     const jsonData = {
+        auditDetails: options.auditDetails,
         apiVersion: options.apiVersion,
         commands: options.commands,
         containerPath: options.containerPath,

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -23,7 +23,7 @@ export interface QueryRequestOptions extends RequestCallbackOptions {
     /** Can be used to override the audit behavior for the table the query is acting on. See {@link AuditBehaviorTypes}. */
     auditBehavior?: AuditBehaviorTypes;
     /** Optional audit details to record in the transaction audit log for this command. */
-    auditDetails?: any;
+    auditDetails?: Record<string, any>;
     /** Can be used to provide a comment from the user that will be attached to certain detailed audit log records. */
     auditUserComment?: string;
     /**
@@ -217,7 +217,7 @@ export interface Command {
     auditBehavior?: AuditBehaviorTypes;
 
     /** Optional audit details to record in the transaction audit log for this command. */
-    auditDetails?: any;
+    auditDetails?: Record<string, any>;
 
     /** Can be used to provide a comment from the user that will be attached to certain detailed audit log records. */
     auditUserComment?: string;
@@ -277,7 +277,7 @@ export interface SaveRowsOptions extends RequestCallbackOptions<SaveRowsResponse
     /**
      * Optional audit details to record in the transaction audit log for this command.
      */
-    auditDetails?: any;
+    auditDetails?: Record<string, any>;
     /**
      * Version of the API. If this is 13.2 or higher, a request that fails
      * validation will be returned as a successful response. Use the 'errorCount' and 'committed' properties in the


### PR DESCRIPTION
#### Rationale
Adds support for capturing optional audit details in transaction audit logs for query operations.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/200
* https://github.com/LabKey/labkey-ui-components/pull/1874
* https://github.com/LabKey/labkey-ui-premium/pull/838
* https://github.com/LabKey/platform/pull/7145
* https://github.com/LabKey/limsModules/pull/1753
* https://github.com/LabKey/commonAssays/pull/944
* https://github.com/LabKey/premiumModules/pull/391
* https://github.com/LabKey/testAutomation/pull/2763

#### Changes
- Added `auditDetails?: any` parameter to `QueryRequestOptions`, `Command`, and `SaveRowsOptions` interfaces
- Updated `saveRows()`, `sendRequest()`, and `moveRows()` functions to include `auditDetails` in their request payloads
