### PR TITLE
Issue 53449: resolve lineage items from container path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.43.1 - 2025-10-31
+- Issue 53449: resolve lineage items from container path
+
 ### 1.43.0 - 2025-08-29
 - Support `File` values directly in `Assay.importRun()` for `batchProperties` and (run) `properties`
 - Can only be run with corresponding server-side changes in LabKey v25.09

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.1-fb-lineage-53449.0",
+  "version": "1.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.43.1-fb-lineage-53449.0",
+      "version": "1.43.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.27.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.0",
+  "version": "1.43.1-fb-lineage-53449.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.43.0",
+      "version": "1.43.1-fb-lineage-53449.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.27.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.0",
+  "version": "1.43.1-fb-lineage-53449.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.43.1-fb-lineage-53449.0",
+  "version": "1.43.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -181,6 +181,7 @@ export interface LineagePKFilter {
 export interface LineageItemBase {
     comment?: string;
     container: string;
+    containerPath: string;
     cpasType?: string;
     created: string;
     createdBy: string;

--- a/src/labkey/Experiment.ts
+++ b/src/labkey/Experiment.ts
@@ -212,7 +212,7 @@ export interface LineageRunStepBase {
     protocol: LineageItemBase;
 }
 
-export type LineageRunStep = LineageItemBase & LineageIOConfig & LineageRunStepBase;
+export type LineageRunStep = LineageIOConfig & LineageItemBase & LineageRunStepBase;
 
 export interface LineageNodeBase {
     absolutePath: string;
@@ -228,11 +228,11 @@ export interface LineageNodeBase {
 }
 
 /** The shape of a LineageNode is determined by the options specified on the lineage API. */
-export type LineageNode = LineageItemBase & LineageIOConfig & LineageNodeBase;
+export type LineageNode = LineageIOConfig & LineageItemBase & LineageNodeBase;
 
 export interface LineageResponse {
     /** Object containing all lineage nodes in this lineage result. Keyed by node LSID. */
-    nodes: { [lsid: string]: LineageNode };
+    nodes: Record<string, LineageNode>;
     /**
      * When request is made with "lsid" option the response will include a singular "seed".
      * @deprecated since 19.3. Use "seeds" instead.
@@ -472,7 +472,7 @@ export function resolve(options: ResolveOptions): XMLHttpRequest {
 
 // formerly, _saveBatches
 function requestSaveBatches<SuccessPayload>(
-    rawOptions: SaveBatchOptions & SaveBatchesOptions,
+    rawOptions: SaveBatchesOptions & SaveBatchOptions,
     payloadProcessor: (json: any) => SuccessPayload
 ): XMLHttpRequest {
     return request({
@@ -600,7 +600,7 @@ export function saveRuns(options: SaveRunsOptions): XMLHttpRequest {
 
 export interface EntitySequenceActionsOptions extends RequestCallbackOptions {
     containerPath?: string;
-    kindName?: 'SampleSet' | 'DataClass';
+    kindName?: 'DataClass' | 'SampleSet';
     newValue?: number;
     rowId?: number;
     seqType: 'genId' | 'rootSampleCount' | 'sampleCount';


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53449](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53449) by updating the lineage UI to resolve lineage items by `containerPath` rather than `container` (entityId). With this the container filter is resolved correctly based on application configuration so that lookup values in lineage details display as expected.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/201
- https://github.com/LabKey/labkey-ui-components/pull/1880
- https://github.com/LabKey/platform/pull/7166
- https://github.com/LabKey/limsModules/pull/1769

#### Changes
- Update `LineageItemBase` interface to align with server provided properties.
