### PR TITLE
GitHub Issue 966: Grid filter UI parses URL parameter incorrectly for array data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.X - 2026-X
+- GitHub Issue 966: Grid filter UI parses URL parameter incorrectly for array data
+
 ### 1.51.0 - 2026-03-31
 - Package updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.X - 2026-X
+### 1.51.1 - 2026-04-08
 - GitHub Issue 966: Grid filter UI parses URL parameter incorrectly for array data
 
 ### 1.51.0 - 2026-03-31

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.0",
+  "version": "1.51.1-mvtcBatch3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.51.0",
+      "version": "1.51.1-mvtcBatch3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.1-mvtcBatch3.1",
+  "version": "1.51.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.51.1-mvtcBatch3.1",
+      "version": "1.51.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.1-mvtcBatch3.1",
+  "version": "1.51.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.0",
+  "version": "1.51.1-mvtcBatch3.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/filter/Types.spec.ts
+++ b/src/labkey/filter/Types.spec.ts
@@ -82,6 +82,20 @@ describe('parseValue', () => {
             expect(type.parseValue(value)).toEqual(['value1', 'value2', 'value3']);
         });
 
+        it('should parse JSON formatted values containing closing brace in value', () => {
+            const type = Types.IN;
+            const value = '{json:["a}b;c"]}';
+            expect(type.parseValue(value)).toEqual(['a}b;c']);
+        });
+
+        it('should round-trip values containing both separator and closing brace', () => {
+            const type = Types.IN;
+            const original = ['a}b;c', 'x;y}z'];
+            const encoded = type.getURLParameterValue(original);
+            expect(encoded).toBe('{json:["a}b;c","x;y}z"]}');
+            expect(type.parseValue(encoded)).toEqual(original);
+        });
+
         it('should fall back to regex parsing if JSON is invalid', () => {
             const type = Types.IN;
             // Invalid JSON: missing closing quote for value2

--- a/src/labkey/filter/Types.ts
+++ b/src/labkey/filter/Types.ts
@@ -561,7 +561,8 @@ export function getFilterTypesForType(jsonType: JsonType, mvEnabled?: boolean): 
 const NEW_LINE_SEP = '\n';
 
 export function parseMultiValueFilterString(type: IFilterType, value: string) {
-    if (value.indexOf('{json:') === 0 && value.indexOf('}') === value.length - 1) {
+    // GH Issue 966: Grid filter UI parses URL parameter incorrectly for value a}b;c
+    if (value.startsWith('{json:') && value.endsWith('}')) {
         try {
             return JSON.parse(value.substring('{json:'.length, value.length - 1));
         } catch {


### PR DESCRIPTION
#### Rationale
GitHub Issue 966: Grid filter UI parses URL parameter incorrectly for array data

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/213
- https://github.com/LabKey/labkey-ui-components/pull/1969
- https://github.com/LabKey/labkey-ui-premium/pull/923
- https://github.com/LabKey/platform/pull/7540
- https://github.com/LabKey/limsModules/pull/2081

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
