### PR TITLE
Add LABKEY.mcpReady

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.51.3 - 2026-05-15
+- Add `mcpReady` to types
+
 ### 1.51.2 - 2026-05-12
 - Package updates
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.3-fb-mcp-calc-cols.0",
+  "version": "1.51.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.51.3-fb-mcp-calc-cols.0",
+      "version": "1.51.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.2",
+  "version": "1.51.3-fb-mcp-calc-cols.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.51.2",
+      "version": "1.51.3-fb-mcp-calc-cols.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.3-fb-mcp-calc-cols.0",
+  "version": "1.51.3",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.2",
+  "version": "1.51.3-fb-mcp-calc-cols.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/constants.ts
+++ b/src/labkey/constants.ts
@@ -127,6 +127,7 @@ export type LabKey = {
     isDocumentClosed: string;
     jdkJavaDocLinkPrefix: string;
     login: LoginConfiguration;
+    mcpReady?: boolean;
     moduleContext?: Record<string, any>;
     pageAdminMode: boolean;
     postParameters?: any;


### PR DESCRIPTION
#### Rationale
This supports MCP servicing on the client by adding a new flag.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/215
- https://github.com/LabKey/labkey-ui-components/pull/2002
- https://github.com/LabKey/platform/pull/7665
- https://github.com/LabKey/limsModules/pull/2203
- https://github.com/LabKey/premiumModules/pull/561
- https://github.com/LabKey/testAutomation/pull/2999

#### Changes
- Expose a new `mcpReady` flag on the `LABKEY` object typings.
