### PR TITLE
Allow require reason on storage changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 1.X - 2026-X
-- Add `auditUserComment` option to `Storage.createStorageItem`, `Storage.updateStorageItem`, and `Storage.deleteStorageItem` for attaching a reason to the audit log record
+- Pass `auditUserComment` option to `Storage.deleteStorageItem` for attaching a reason to the audit log record
 
 ### 1.51.4 - 2026-06-17
 - Package updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.X - 2026-X
+- Add `auditUserComment` option to `Storage.createStorageItem`, `Storage.updateStorageItem`, and `Storage.deleteStorageItem` for attaching a reason to the audit log record
+
 ### 1.51.4 - 2026-06-17
 - Package updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.X - 2026-X
+### 1.51.5 - 2026-06-22
 - Pass `auditUserComment` option to `Storage.deleteStorageItem` for attaching a reason to the audit log record
 
 ### 1.51.4 - 2026-06-17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.5-fb-storageComment.1",
+  "version": "1.51.5-fb-storageComment.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.51.5-fb-storageComment.1",
+      "version": "1.51.5-fb-storageComment.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.29.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.5-fb-storageComment.2",
+  "version": "1.51.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.51.5-fb-storageComment.2",
+      "version": "1.51.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.29.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.4",
+  "version": "1.51.5-fb-storageComment.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.51.4",
+      "version": "1.51.5-fb-storageComment.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.5-fb-storageComment.2",
+  "version": "1.51.5",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.4",
+  "version": "1.51.5-fb-storageComment.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.51.5-fb-storageComment.1",
+  "version": "1.51.5-fb-storageComment.2",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/labkey/Storage.ts
+++ b/src/labkey/Storage.ts
@@ -27,8 +27,6 @@ export interface StorageCommandResponse {
 }
 
 export interface IStorageCommandOptions extends RequestCallbackOptions<StorageCommandResponse> {
-    /** Optional comment that will be attached to the audit log record for this storage change. */
-    auditUserComment?: string;
     /** The container path in which to execute the command. */
     containerPath?: string;
     /** The specific set of props will differ for each storage item type:
@@ -38,6 +36,8 @@ export interface IStorageCommandOptions extends RequestCallbackOptions<StorageCo
      * - Shelf/Rack/Canister: name, description, locationId (rowId of the parent freezer or Shelf/Rack/Canister)
      * - Storage Unit Type: name, description, unitType (one of the following: "Box", "Plate", "Bag", "Cane", "Tube Rack"), rows, cols (required if positionFormat is not "Num"), positionFormat (one of the following: "Num", "AlphaNum", "AlphaAlpha", "NumAlpha", "NumNum"), positionOrder (one of the following: "RowColumn", "ColumnRow")
      * - Terminal Storage Location: name, description, typeId (rowId of the Storage Unit Type), locationId (rowId of the parent freezer or Shelf/Rack/Canister)
+     *
+     * In addition, any storage item type accepts an optional `auditUserComment` (string) which is recorded as the "Reason" on the resulting audit event.
      */
     props: Record<string, any>;
     /** Storage items can be of the following types: Physical Location, Freezer, Primary Storage, Shelf, Rack, Canister, Storage Unit Type, or Terminal Storage Location. */
@@ -131,7 +131,6 @@ export function createStorageItem(config: IStorageCommandOptions): XMLHttpReques
         jsonData: {
             type: config.type,
             props: config.props,
-            auditUserComment: config.auditUserComment,
         },
         success: getCallbackWrapper(getOnSuccess(config), config.scope),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true),
@@ -163,7 +162,8 @@ export function createStorageItem(config: IStorageCommandOptions): XMLHttpReques
  *      type: 'Terminal Storage Location',
  *      props: {
  *          rowId: 19382,
- *          locationId: 8089 // move Box #1 from Shelf #1 to Shelf #2
+ *          locationId: 8089, // move Box #1 from Shelf #1 to Shelf #2
+ *          auditUserComment: 'Relocated to make room for incoming samples from Lab B.'
  *      },
  *      success: function(response) {
  *          console.log(response);
@@ -178,7 +178,6 @@ export function updateStorageItem(config: IStorageCommandOptions): XMLHttpReques
         jsonData: {
             type: config.type,
             props: config.props,
-            auditUserComment: config.auditUserComment,
         },
         success: getCallbackWrapper(getOnSuccess(config), config.scope),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true),
@@ -205,6 +204,20 @@ export interface DeleteStorageCommandOptions extends IStorageCommandOptions {
  *      }
  * });
  * ```
+ *
+ * ```js
+ * // Delete a box and record a reason in the audit log
+ * LABKEY.Storage.deleteStorageItem({
+ *      type: 'Terminal Storage Location',
+ *      rowId: 19382,
+ *      props: {
+ *          auditUserComment: 'Decommissioned; replaced by Box #2.'
+ *      },
+ *      success: function(response) {
+ *          console.log(response);
+ *      }
+ * });
+ * ```
  */
 export function deleteStorageItem(config: DeleteStorageCommandOptions): XMLHttpRequest {
     return request({
@@ -212,8 +225,10 @@ export function deleteStorageItem(config: DeleteStorageCommandOptions): XMLHttpR
         method: 'POST',
         jsonData: {
             type: config.type,
-            props: { rowId: config.rowId },
-            auditUserComment: config.auditUserComment,
+            props: {
+                rowId: config.rowId,
+                ...(config.props?.auditUserComment !== undefined && { auditUserComment: config.props.auditUserComment }),
+            },
         },
         success: getCallbackWrapper(getOnSuccess(config), config.scope),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true),

--- a/src/labkey/Storage.ts
+++ b/src/labkey/Storage.ts
@@ -27,6 +27,8 @@ export interface StorageCommandResponse {
 }
 
 export interface IStorageCommandOptions extends RequestCallbackOptions<StorageCommandResponse> {
+    /** Optional comment that will be attached to the audit log record for this storage change. */
+    auditUserComment?: string;
     /** The container path in which to execute the command. */
     containerPath?: string;
     /** The specific set of props will differ for each storage item type:
@@ -129,6 +131,7 @@ export function createStorageItem(config: IStorageCommandOptions): XMLHttpReques
         jsonData: {
             type: config.type,
             props: config.props,
+            auditUserComment: config.auditUserComment,
         },
         success: getCallbackWrapper(getOnSuccess(config), config.scope),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true),
@@ -175,6 +178,7 @@ export function updateStorageItem(config: IStorageCommandOptions): XMLHttpReques
         jsonData: {
             type: config.type,
             props: config.props,
+            auditUserComment: config.auditUserComment,
         },
         success: getCallbackWrapper(getOnSuccess(config), config.scope),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true),
@@ -209,6 +213,7 @@ export function deleteStorageItem(config: DeleteStorageCommandOptions): XMLHttpR
         jsonData: {
             type: config.type,
             props: { rowId: config.rowId },
+            auditUserComment: config.auditUserComment,
         },
         success: getCallbackWrapper(getOnSuccess(config), config.scope),
         failure: getCallbackWrapper(getOnFailure(config), config.scope, true),


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/218
* https://github.com/LabKey/labkey-ui-components/pull/2019
* https://github.com/LabKey/labkey-ui-premium/pull/970
* https://github.com/LabKey/limsModules/pull/2273

#### Changes
* Pass `auditUserComment` option to `Storage.deleteStorageItem` for attaching a reason to the audit log record
* Update Docs about `auditUserComment` option for storage update
