### PR TITLE
Emit CommonJS for global bundle to restore LABKEY overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.52.1-fb-object-assign.1",
+  "version": "1.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.52.1-fb-object-assign.1",
+      "version": "1.52.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.52.1-fb-object-assign.0",
+  "version": "1.52.1-fb-object-assign.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.52.1-fb-object-assign.0",
+      "version": "1.52.1-fb-object-assign.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@labkey/api",
-  "version": "1.52.0",
+  "version": "1.52.1-fb-object-assign.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@labkey/api",
-      "version": "1.52.0",
+      "version": "1.52.1-fb-object-assign.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.52.0",
+  "version": "1.52.1-fb-object-assign.0",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.52.1-fb-object-assign.0",
+  "version": "1.52.1-fb-object-assign.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labkey/api",
-  "version": "1.52.1-fb-object-assign.1",
+  "version": "1.52.1",
   "description": "JavaScript client API for LabKey Server",
   "scripts": {
     "build": "npm run build:dist && npm run build:docs",

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -29,7 +29,6 @@ import * as API from './index';
 declare let LABKEY: any;
 
 LABKEY.ActionURL = API.ActionURL;
-LABKEY.Ajax = API.Ajax;
 LABKEY.App = API.App;
 LABKEY.Domain = API.Domain;
 LABKEY.Exp = API.Exp;
@@ -49,6 +48,7 @@ LABKEY.Visualization = API.Visualization;
 
 // The following namespaces are extended at runtime by legacy DOM overrides.
 // Since we are now targeting ES2023+, we need to create writable plain objects so the overrides can mutate.
+LABKEY.Ajax = Object.assign({}, API.Ajax);
 LABKEY.Assay = Object.assign({}, API.Assay);
 LABKEY.Experiment = Object.assign({}, API.Experiment);
 LABKEY.Query = Object.assign({}, API.Query);

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -29,9 +29,12 @@ import * as API from './index';
 declare let LABKEY: any;
 
 LABKEY.ActionURL = API.ActionURL;
+LABKEY.Ajax = API.Ajax;
 LABKEY.App = API.App;
+LABKEY.Assay = API.Assay;
 LABKEY.Domain = API.Domain;
 LABKEY.Exp = API.Exp;
+LABKEY.Experiment = API.Experiment;
 LABKEY.FieldKey = API.FieldKey;
 LABKEY.Filter = API.Filter;
 LABKEY.List = API.List;
@@ -39,21 +42,15 @@ LABKEY.Message = API.Message;
 LABKEY.MultiRequest = API.MultiRequest;
 LABKEY.ParticipantGroup = API.ParticipantGroup;
 LABKEY.Pipeline = API.Pipeline;
+LABKEY.Query = API.Query;
 LABKEY.QueryKey = API.QueryKey;
 LABKEY.Report = API.Report;
 LABKEY.SchemaKey = API.SchemaKey;
+LABKEY.Security = API.Security;
 LABKEY.Specimen = API.Specimen;
 LABKEY.Storage = API.Storage;
+LABKEY.Utils = API.Utils;
 LABKEY.Visualization = API.Visualization;
-
-// The following namespaces are extended at runtime by legacy DOM overrides.
-// Since we are now targeting ES2023+, we need to create writable plain objects so the overrides can mutate.
-LABKEY.Ajax = Object.assign({}, API.Ajax);
-LABKEY.Assay = Object.assign({}, API.Assay);
-LABKEY.Experiment = Object.assign({}, API.Experiment);
-LABKEY.Query = Object.assign({}, API.Query);
-LABKEY.Security = Object.assign({}, API.Security);
-LABKEY.Utils = Object.assign({}, API.Utils);
 
 LABKEY.__package__ = __package__;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,6 @@ const umdPackageConfig = {
                         outDir: path.resolve(__dirname, 'dist'),
                         declaration: true,
                         removeComments: true,
-                        target: 'ES6',
                     },
                     onlyCompileBundledFiles: true,
                 },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,9 +24,20 @@ const apiGlobalConfig = {
                 loader: 'ts-loader',
                 options: {
                     onlyCompileBundledFiles: true,
+                    // Emit CommonJS ("nodenext", since package.json intentionally has no "type":"module") so LABKEY
+                    // namespaces stay shared, writable exports that legacy runtime overrides can patch.
+                    compilerOptions: {
+                        module: 'nodenext',
+                        moduleResolution: 'nodenext',
+                    },
                 },
             },
         ],
+    },
+
+    optimization: {
+        // Disable scope hoisting so cross-module references resolve through the shared, patchable exports objects.
+        concatenateModules: false,
     },
 
     output: {


### PR DESCRIPTION
#### Rationale
Setting the compile target to `ES2023` flipped the global browser bundles from CommonJS to ES module emit, which broke legacy runtime overrides of the `LABKEY.*` namespaces. ESM exports are read-only getters that webpack also inlines via scope hoisting, so the namespaces can no longer be patched. Since `module`/`moduleResolution` are build-time-only and independent of the language target, this restores CommonJS emit for the global bundles while keeping the `ES2023` target.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/219 (Previous changes that brought in ES2023)
- https://github.com/LabKey/labkey-api-js/pull/221
- https://github.com/LabKey/labkey-ui-components/pull/2034
- https://github.com/LabKey/labkey-ui-premium/pull/986
- https://github.com/LabKey/limsModules/pull/2332
- https://github.com/LabKey/platform/pull/7834

#### Changes
- Emit CommonJS (`nodenext`) and disable module concatenation in global bundles
- Assign `LABKEY.*` namespaces directly from the API exports
- Remove target override in UMD build